### PR TITLE
fix link to stackhpc.com

### DIFF
--- a/source/index.html.de
+++ b/source/index.html.de
@@ -318,7 +318,7 @@
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
-	  <a href="https://stackhpc.com">
+	  <a href="https://www.stackhpc.com">
           <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC" />
 	  </a>
       </div>

--- a/source/index.html.de
+++ b/source/index.html.de
@@ -134,6 +134,8 @@
         <h2>Konferenzbeiträge</h2>
         <p class="lead">
           <ul>
+            <li>(2020-11-19) <a href="https://www.youtube.com/watch?v=MkTMFRzP7jA">
+                Dr. Ronny Reinhardt, Pierre Gronlier: GAIA-X Demonstrator</a></li>
             <li>(2020-11-19) <a href="https://osb-alliance.de/veranstaltungen/open-source-day-2020-forum-fuer-digitale-souveraenitaet">
                 Kurt Garloff, Peter Ganten: Digitale Souveränität mit Sovereign Cloud Stack</a>
 		    <a href="slides/20201119-OSD.pdf"> (Folien)</a></li>

--- a/source/index.html.de
+++ b/source/index.html.de
@@ -30,7 +30,7 @@
 <body>
   <nav class="navbar fixed-top">
     <a href="/" class="navbar-left" title="scs.community">
-      <img src="images/logo-scs-vert.png" class="logo-scs" alt="SCS Logo" title="SCS Logo" />
+      <img src="images/logo-scs-vert.png" class="logo-scs" alt="SCS Logo" title="Sovereign Cloud Stack" />
     </a>
     <div class="container">
       <div class="row">
@@ -155,7 +155,7 @@
     <div class="row">
       <div class="col-12">
         <h2>GAIA-X &ndash; Federated Data Infrastructure</h2>
-        <img src="images/logo-gaia-x.png" class="logo-gaia-x" alt="GAIA-X Logo" title="GAIA-X Logo" />
+        <img src="images/logo-gaia-x.png" class="logo-gaia-x" alt="GAIA-X Logo" title="GAIA-X" />
         <p class="lead">
           Auf dem Digital-Gipfel 2019 in Dortmund wurde das
           <a href="https://www.data-infrastructure.eu/">Projekt GAIA-X</a>
@@ -175,7 +175,7 @@
     <div class="row">
       <div class="col-12">
         <h2>Bundesagentur für Sprunginnovationen</h2>
-        <img src="images/logo-sprind.png" class="logo-sprind" alt="SPRIND Logo" title="SPRIND Logo" />
+        <img src="images/logo-sprind.png" class="logo-sprind" alt="SPRIND Logo" title="SPRIND" />
         <p class="lead">
           Die Bundesagentur für Sprunginnovationen – SPRIND – mit Sitz in Leipzig schließt eine Lücke
           in der deutschen Innovationslandschaft: Sie findet Antworten auf die ungelösten technologischen,
@@ -240,43 +240,43 @@
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
 	  <a href="https://23technologies.cloud/">
-          <img src="images/logo-23technologies.png" class="logo-23technologies" alt="23 Technologies Logo" title="23 Technologies Logo" />
+          <img src="images/logo-23technologies.png" class="logo-23technologies" alt="23 Technologies Logo" title="23 Technologies" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://b1-systems.de/">
-          <img src="images/logo-b1-systems.svg" class="logo-b1-systems" alt="B1 Systems Logo" title="B1 Systems Logo" />
+          <img src="images/logo-b1-systems.svg" class="logo-b1-systems" alt="B1 Systems Logo" title="B1 Systems" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://betacloud-solutions.de/">
-          <img src="images/logo-betacloud-solutions.png" class="logo-betacloud-solutions" alt="Betacloud Solutions Logo" title="Betacloud Solutions Logo" />
+          <img src="images/logo-betacloud-solutions.png" class="logo-betacloud-solutions" alt="Betacloud Solutions Logo" title="Betacloud Solutions" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://citynetwork.eu/">
-          <img src="images/logo-citynetwork.png" class="logo-citynetwork" alt="Citynetwork Logo" title="Citynetwork Logo" />
+          <img src="images/logo-citynetwork.png" class="logo-citynetwork" alt="Citynetwork Logo" title="Citynetwork" />
       </div>
     </div>
 
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
 	  <a href="https://cloudandheat.com/">
-          <img src="images/logo-candh.png" class="logo-cloudandheat" alt="Cloud&Heat Logo" title="Cloud&Heat Logo" />
+          <img src="images/logo-candh.png" class="logo-cloudandheat" alt="Cloud&Heat Logo" title="Cloud&Heat" />
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://dilossacon.de/">
-          <img src="images/logo-dilossacon.png" class="logo-dilossacon" alt="Dilossacon Logo" title="Dilossacon Logo" />
+          <img src="images/logo-dilossacon.png" class="logo-dilossacon" alt="Dilossacon Logo" title="Dilossacon" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://gonicus.de/">
-          <img src="images/logo-gonicus.png" class="logo-gonicus" alt="GONICUS Logo" title="GONICUS Logo" />
+          <img src="images/logo-gonicus.png" class="logo-gonicus" alt="GONICUS Logo" title="GONICUS" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://www.opencore.com/">
-          <img src="images/logo-opencore.png" class="logo-opencore" alt="Logo" title="OpenCore Logo" />
+          <img src="images/logo-opencore.png" class="logo-opencore" alt="Logo" title="OpenCore" />
 	  </a>
       </div>
     </div>
@@ -284,22 +284,22 @@
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
 	  <a href="https://osb-alliance.de/">
-          <img src="images/logo-osba.svg" class="logo-osba" alt="Logo" title="OSBA Logo" />
+          <img src="images/logo-osba.svg" class="logo-osba" alt="Logo" title="OSBA" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://open-xchange.com/">
-          <img src="images/logo-open-xchange.svg" class="logo-open-xchange" alt="Open-Xchange Logo" title="Open-Xchange Logo" />
+          <img src="images/logo-open-xchange.svg" class="logo-open-xchange" alt="Open-Xchange Logo" title="Open-Xchange" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://osf.dev/">
-          <div class="container-logo-openstack-foundation"><img src="images/logo-openstack-foundation.svg" class="logo-openstack-foundation" alt="OpenStack Foundation Logo" title="OpenStack Foundation Logo" /></div>
+          <div class="container-logo-openstack-foundation"><img src="images/logo-openstack-foundation.svg" class="logo-openstack-foundation" alt="OpenStack Foundation Logo" title="OpenStack Foundation" /></div>
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://ovhcloud.com/">
-          <img src="images/logo-ovhcloud.svg" class="logo-ovhcloud" alt="OVHcloud Logo" title="OVHcloud Logo" />
+          <img src="images/logo-ovhcloud.svg" class="logo-ovhcloud" alt="OVHcloud Logo" title="OVHcloud" />
 	  </a>
       </div>
     </div>
@@ -307,29 +307,29 @@
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
 	  <a href="https://plusserver.com/">
-          <img src="images/logo-plusserver.png" class="logo-plusserver" alt="PlusServer Logo" title="PlusServer Logo" />
+          <img src="images/logo-plusserver.png" class="logo-plusserver" alt="PlusServer Logo" title="PlusServer" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://sprind.org/">
-          <img src="images/logo-sprind.png" class="logo-sprind-2" alt="SPRIND Logo" title="SPRIND Logo" />
+          <img src="images/logo-sprind.png" class="logo-sprind-2" alt="SPRIND Logo" title="SPRIND" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://stackhpc.com">
-          <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC Logo" />
+          <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://open-telekom-cloud.com/">
-          <img src="images/logo-telekom-4cpde.svg" class="logo-telekom" alt="Telekom Logo" title="Deutsche Telekom Logo" />
+          <img src="images/logo-telekom-4cpde.svg" class="logo-telekom" alt="Telekom Logo" title="Deutsche Telekom" />
 	  </a>
       </div>
     </div>
 
       <div class="col-md-3 col-sm-6">
 	  <a href="https://univention.de/">
-          <img src="images/logo-univention.png" class="logo-univention" alt="Univention Logo" title="Univention Logo" />
+          <img src="images/logo-univention.png" class="logo-univention" alt="Univention Logo" title="Univention" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">

--- a/source/index.html.en
+++ b/source/index.html.en
@@ -321,7 +321,7 @@
           </a>
       </div>
       <div class="col-md-3 col-sm-6">
-          <a href="https://stackhpc.com">
+          <a href="https://www.stackhpc.com">
           <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC" />
           </a>
       </div>

--- a/source/index.html.en
+++ b/source/index.html.en
@@ -30,7 +30,7 @@
 <body>
   <nav class="navbar fixed-top">
     <a href="/" class="navbar-left" title="scs.community">
-      <img src="images/logo-scs-vert.png" class="logo-scs" alt="SCS logo" title="SCS logo" />
+      <img src="images/logo-scs-vert.png" class="logo-scs" alt="SCS logo" title="Sovereign Cloud Stack" />
     </a>
     <div class="container">
       <div class="row">
@@ -156,7 +156,7 @@
     <div class="row">
       <div class="col-12">
         <h2>GAIA-X &ndash; Federated Data Infrastructure</h2>
-        <img src="images/logo-gaia-x.png" class="logo-gaia-x" alt="GAIA-X logo" title="GAIA-X logo" />
+        <img src="images/logo-gaia-x.png" class="logo-gaia-x" alt="GAIA-X logo" title="GAIA-X" />
         <p class="lead">
 	  On the digital summit 2019 in Dortmund, the
           <a href="https://www.data-infrastructure.eu/">GAIA-X project</a>
@@ -177,7 +177,7 @@
     <div class="row">
       <div class="col-12">
         <h2>Federal Agency for Disruptive Innovations</h2>
-        <img src="images/logo-sprind.png" class="logo-sprind" alt="SPRIND logo" title="SPRIND logo" />
+        <img src="images/logo-sprind.png" class="logo-sprind" alt="SPRIND logo" title="SPRIND" />
         <p class="lead">
           The Federal Agency for Disruptive Innovations - SPRIND - based in Leipzig closes a gap in the German
           innovation landscape: It finds answers to the unsolved technological, ecological and social
@@ -243,43 +243,43 @@
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
           <a href="https://23technologies.cloud/">
-          <img src="images/logo-23technologies.png" class="logo-23technologies" alt="23 Technologies Logo" title="23 Technologies Logo" />
+          <img src="images/logo-23technologies.png" class="logo-23technologies" alt="23 Technologies Logo" title="23 Technologies" />
           </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://b1-systems.de/">
-          <img src="images/logo-b1-systems.svg" class="logo-b1-systems" alt="B1 Systems Logo" title="B1 Systems Logo" />
+          <img src="images/logo-b1-systems.svg" class="logo-b1-systems" alt="B1 Systems Logo" title="B1 Systems" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://betacloud-solutions.de/">
-          <img src="images/logo-betacloud-solutions.png" class="logo-betacloud-solutions" alt="Betacloud Solutions Logo" title="Betacloud Solutions Logo" />
+          <img src="images/logo-betacloud-solutions.png" class="logo-betacloud-solutions" alt="Betacloud Solutions Logo" title="Betacloud Solutions" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://citynetwork.eu/">
-          <img src="images/logo-citynetwork.png" class="logo-citynetwork" alt="Citynetwork Logo" title="Citynetwork Logo" />
+          <img src="images/logo-citynetwork.png" class="logo-citynetwork" alt="Citynetwork Logo" title="Citynetwork" />
       </div>
     </div>
 
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
 	  <a href="https://cloudandheat.com/">
-          <img src="images/logo-candh.png" class="logo-cloudandheat" alt="Cloud&Heat Logo" title="Cloud&Heat Logo" />
+          <img src="images/logo-candh.png" class="logo-cloudandheat" alt="Cloud&Heat Logo" title="Cloud&Heat" />
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://dilossacon.de/">
-          <img src="images/logo-dilossacon.png" class="logo-dilossacon" alt="Dilossacon Logo" title="Dilossacon Logo" />
+          <img src="images/logo-dilossacon.png" class="logo-dilossacon" alt="Dilossacon Logo" title="Dilossacon" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://gonicus.de/">
-          <img src="images/logo-gonicus.png" class="logo-gonicus" alt="GONICUS Logo" title="GONICUS Logo" />
+          <img src="images/logo-gonicus.png" class="logo-gonicus" alt="GONICUS Logo" title="GONICUS" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://www.opencore.com/">
-          <img src="images/logo-opencore.png" class="logo-opencore" alt="Logo" title="OpenCore Logo" />
+          <img src="images/logo-opencore.png" class="logo-opencore" alt="Logo" title="OpenCore" />
 	  </a>
       </div>
     </div>
@@ -287,22 +287,22 @@
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
 	  <a href="https://osb-alliance.de/">
-          <img src="images/logo-osba.svg" class="logo-osba" alt="Logo" title="OSBA Logo" />
+          <img src="images/logo-osba.svg" class="logo-osba" alt="Logo" title="OSBA" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://open-xchange.com/">
-          <img src="images/logo-open-xchange.svg" class="logo-open-xchange" alt="Open-Xchange Logo" title="Open-Xchange Logo" />
+          <img src="images/logo-open-xchange.svg" class="logo-open-xchange" alt="Open-Xchange Logo" title="Open-Xchange" />
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://osf.dev/">
-          <div class="container-logo-openstack-foundation"><img src="images/logo-openstack-foundation.svg" class="logo-openstack-foundation" alt="OpenStack Foundation Logo" title="OpenStack Foundation Logo" /></div>
+          <div class="container-logo-openstack-foundation"><img src="images/logo-openstack-foundation.svg" class="logo-openstack-foundation" alt="OpenStack Foundation Logo" title="OpenStack Foundation" /></div>
 	  </a>
       </div>
       <div class="col-md-3 col-sm-6">
 	  <a href="https://ovhcloud.com/">
-          <img src="images/logo-ovhcloud.svg" class="logo-ovhcloud" alt="OVHcloud Logo" title="OVHcloud Logo" />
+          <img src="images/logo-ovhcloud.svg" class="logo-ovhcloud" alt="OVHcloud Logo" title="OVHcloud" />
 	  </a>
       </div>
     </div>
@@ -310,29 +310,29 @@
     <div class="row d-flex align-items-baseline">
       <div class="col-md-3 col-sm-6">
           <a href="https://plusserver.com/">
-          <img src="images/logo-plusserver.png" class="logo-plusserver" alt="PlusServer Logo" title="PlusServer Logo" />
+          <img src="images/logo-plusserver.png" class="logo-plusserver" alt="PlusServer Logo" title="PlusServer" />
           </a>
       </div>
       <div class="col-md-3 col-sm-6">
           <a href="https://sprind.org/">
-          <img src="images/logo-sprind.png" class="logo-sprind-2" alt="SPRIND Logo" title="SPRIND Logo" />
+          <img src="images/logo-sprind.png" class="logo-sprind-2" alt="SPRIND Logo" title="SPRIND" />
           </a>
       </div>
       <div class="col-md-3 col-sm-6">
           <a href="https://stackhpc.com">
-          <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC Logo" />
+          <img src="images/logo-stackhpc.png" class="logo-stackhpc" alt="StackHPC Logo" title="STackHPC" />
           </a>
       </div>
       <div class="col-md-3 col-sm-6">
           <a href="https://open-telekom-cloud.com/">
-          <img src="images/logo-telekom-4cpde.svg" class="logo-telekom" alt="Telekom Logo" title="Deutsche Telekom Logo" />
+          <img src="images/logo-telekom-4cpde.svg" class="logo-telekom" alt="Telekom Logo" title="Deutsche Telekom" />
           </a>
       </div>
     </div>
 
       <div class="col-md-3 col-sm-6">
           <a href="https://univention.de/">
-          <img src="images/logo-univention.png" class="logo-univention" alt="Univention Logo" title="Univention Logo" />
+          <img src="images/logo-univention.png" class="logo-univention" alt="Univention Logo" title="Univention" />
           </a>
       </div>
       <div class="col-md-3 col-sm-6">

--- a/source/index.html.en
+++ b/source/index.html.en
@@ -135,6 +135,8 @@
         <h2>Conference contributions</h2>
         <p class="lead">
           <ul>
+            <li>(2020-11-19) <a href="https://www.youtube.com/watch?v=MkTMFRzP7jA">
+                Dr. Ronny Reinhardt, Pierre Gronlier: GAIA-X Demonstrator</a></li>
             <li>(2020-11-19) <a href="https://osb-alliance.de/veranstaltungen/open-source-day-2020-forum-fuer-digitale-souveraenitaet">
                 Kurt Garloff, Peter Ganten: Digitale Souveränität mit Sovereign Cloud Stack</a>
 		    <a href="slides/20201119-OSD.pdf"> (Slides)</a></li>


### PR DESCRIPTION
At the moment the link to https://stackhpc.com results in an error because their certificate is only valid for www.stackhpc.com and looks like there is no redirect from https://stackhpc.com to https://www.stackhpc.com in place.

This patch will fix this behaviour by using https://www.stackhpc.com as link instead of https://stackhpc.com