### PR TITLE
Use dynamic spacing.

### DIFF
--- a/source/css/styles.css
+++ b/source/css/styles.css
@@ -19,7 +19,6 @@ body {
   box-shadow: 0 8px 6px -6px #999;
   background-color: white !important;
   font-size: 12pt;
-  height: 160px;
 }
 
 .logo-pic {

--- a/source/header.html
+++ b/source/header.html
@@ -30,7 +30,7 @@
 
 </head>
 
-  <nav class="navbar fixed-top">
+  <nav class="navbar fixed-top py-1">
     <a href="/" class="navbar-left" title="scs.community">
       <img src="/images/logo-scs-vert.png" class="logo-pic" alt="SCS Logo" title="Sovereign Cloud Stack" />
     </a>
@@ -76,5 +76,5 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="container py-3">
 

--- a/source/header_de.html
+++ b/source/header_de.html
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <nav class="navbar fixed-top">
+  <nav class="navbar fixed-top py-1">
     <a href="/" class="navbar-left" title="scs.community">
       <img src="/images/logo-scs-vert.png" class="logo-pic" alt="SCS Logo" title="Sovereign Cloud Stack" />
     </a>
@@ -80,5 +80,5 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="container py-3">
 

--- a/source/header_en.html
+++ b/source/header_en.html
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <nav class="navbar fixed-top">
+  <nav class="navbar fixed-top py-1">
     <a href="/" class="navbar-left" title="scs.community">
       <img src="/images/logo-scs-vert.png" class="logo-pic" alt="SCS Logo" title="Sovereign Cloud Stack" />
     </a>
@@ -80,5 +80,5 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="container py-3">
 

--- a/source/index.html.de
+++ b/source/index.html.de
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <nav class="navbar fixed-top">
+  <nav class="navbar fixed-top py-1">
     <a href="/" class="navbar-left" title="scs.community">
       <img src="/images/logo-scs-vert.png" class="logo-pic" alt="SCS Logo" title="Sovereign Cloud Stack" />
     </a>
@@ -80,7 +80,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="container py-3">
     <div class="row">
       <div class="col-12">
         <h1>Sovereign Cloud Stack</h1>

--- a/source/index.html.en
+++ b/source/index.html.en
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <nav class="navbar fixed-top">
+  <nav class="navbar fixed-top py-1">
     <a href="/" class="navbar-left" title="scs.community">
       <img src="/images/logo-scs-vert.png" class="logo-pic" alt="SCS Logo" title="Sovereign Cloud Stack" />
     </a>
@@ -80,7 +80,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="container py-3">
     <div class="row">
       <div class="col-12">
         <h1>Sovereign Cloud Stack</h1>


### PR DESCRIPTION
bootstrap docu advices to use py-N to increase spacing.
So we include a py-1 in the navbar and py-3 in the body
below.
This leads to working menu on both mobile and desktop.

Signed-off-by: Kurt Garloff <kurt@garloff.de>