### PR TITLE
Use Lato font for web site.

### DIFF
--- a/source/css/styles.css
+++ b/source/css/styles.css
@@ -9,7 +9,7 @@
 }
 
 body {
-  font-family: 'Montserrat', sans-serif !important;
+  font-family: 'Lato', sans-serif !important;
   padding-top: 150px;
 }
 
@@ -146,12 +146,13 @@ ul {
 }
 
 blockquote {
+  font-family: 'Montserrat', sans-serif !important;
   color: rgba(73, 83, 91, 1.0) !important;
   font-size: 1.2em;
   margin: 50px auto;
   padding: 1.2em 30px 1.2em 75px;
   border-left: 8px solid rgba(174, 179, 184, 0.8);
-  line-height: 1.4;
+  line-height: 1.3;
   position: relative;
   background: rgba(174, 179, 184, 0.1);
 }


### PR DESCRIPTION
Except for blockquote, where we use the previous Montserrat.
Also reduce line spacing for blockquotes a bit.

Signed-off-by: Kurt Garloff <kurt@garloff.de>