### PR TITLE
openinfra.org is still not available

### DIFF
--- a/source/logos.yaml
+++ b/source/logos.yaml
@@ -44,7 +44,7 @@ Logos:
     height: 60
   OpenInfra:
     filename: OIF-logo-h31.svg
-    link: https://openinfra.org/
+    link: https://openinfra.dev/
     height: 67
   OpenSourceBizAlliance:
     filename: logo-osba.svg


### PR DESCRIPTION
signed-off-by: vater@bsd.services
openinfra.org is not available. and openinfra.dev seems to be right.
(btw: all the other are links are fine. :-) )
and feel free to edit this commit (pull request) especially for "violating" "ow rules" reasons.