### PR TITLE
openinfra.org is really not available (mergeable :-) )

### DIFF
--- a/source/logos.yaml
+++ b/source/logos.yaml
@@ -44,7 +44,7 @@ Logos:
     height: 60
   OpenInfra:
     filename: OIF-logo-h31.svg
-    link: https://openinfra.org/
+    link: https://openinfra.dev/
     height: 67
   OpenSourceBizAlliance:
     filename: logo-osba.svg


### PR DESCRIPTION
signed-off-by: yater <vater@bsd.services>
openinfra.org is not available. and openinfra.dev seems to be right.
(btw: all the other are links are fine. :-) )
and feel free to edit this commit (pull request) especially for "violating" "ow rules" reasons.
sorry for using this repository "to play around with github and dco (signed-off-by foo) for the first time".