### PR TITLE
Place C&H marker at correct building

### DIFF
--- a/_data/supporter.yml
+++ b/_data/supporter.yml
@@ -34,8 +34,8 @@
   avatar: "avatar-candh.jpg"
   link: "https://www.cloudandheat.com/"
   location:
-    latitude: 51.08052
-    longitude: 13.76233   
+    latitude: 51.08017
+    longitude: 13.76214   
 - name: "Dataport"
   image: "logo-dataport.png"
   avatar: "avatar-dataport.png"


### PR DESCRIPTION
The main office is in Halle 15 on the Zeitenströmung.

The new location is the same as the location marker on OpenStreetMaps.