### PR TITLE
Collapse nav bar into seperated dropdowns

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -1,14 +1,14 @@
 - title: nav.home
   link: /
 
-- title: nav.about
-  link: /about/
-
-- title: nav.use
-  link: /use/
-
-- title: nav.community
-  link: /community/
+- title: nav.discover
+  dropdown:
+    - title: nav.about
+      link: /about/
+    - title: nav.use
+      link: /use/
+    - title: nav.community
+      link: /community/
 
 - title: nav.news
   link: /news/

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -4,12 +4,13 @@ global:
   about: "Sovereign Cloud Stack (SCS) ist eine Open-Source-Code Alternative zu proprietär verfügbarer Cloud-Technologie."
 nav:
   home: "Home"
+  discover: "SCS entdecken"
   about: "Über SCS"
   use: "SCS nutzen"
   community: "Unsere Community"
-  news: "SCS in den Medien"
+  news: "Neuigkeiten"
   jobs: "Offene Stellen"
-  tenders: "Öffentliche Ausschreibungen"
+  tenders: "Ausschreibungen"
 footer:
   trademark: "Sovereign Cloud Stack, SCS und das Logo sind geschützte Marken der Open Source Business Alliance e.V. — Sonstige Marken sind Eigentum ihrer jeweiligen Besitzer."
   imprint: "Impressum"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -4,10 +4,11 @@ global:
   about: "Sovereign Cloud Stack (SCS) is cloud technology built entirely with Open Source Software — as an alternative to propietary cloud technology."
 nav:
   home: "Home"
+  discover: "Discover SCS"
   about: "About SCS"
   use: "Use SCS"
   community: "Our community"
-  news: "SCS in the media"
+  news: "News"
   jobs: "Open positions"
   tenders: "Public tenders"
 footer:

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -16,9 +16,20 @@
       <ul class="navbar-nav me-auto">
         {% for item in site.data.menu %}
         <li class="nav-item">
-          <a class="nav-link" href="{{ site.baseurl }}{{ item.link }}">
-            {% t item.title %}
-          </a>
+          {% if item.dropdown %}
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              {% t item.title %}
+            </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {% for nested in item.dropdown %}
+                  <li><a class="dropdown-item" href="{{ site.baseurl }}{{ nested.link }}">{% t nested.title %}</a></li>
+                {% endfor %}
+            </ul>
+          {% else %}
+            <a class="nav-link" href="{{ site.baseurl }}{{ item.link }}">
+              {% t item.title %}
+            </a>
+          {% endif %}
         </li>
         {% endfor %}
       </ul>

--- a/assets/css/_sass/custom.scss
+++ b/assets/css/_sass/custom.scss
@@ -59,6 +59,10 @@ body {
   padding: 0.5rem 1rem;
 }
 
+.dropdown-menu[data-bs-popper] {
+  left: unset;
+}
+
 a {
     color: $scs-mint;
 }


### PR DESCRIPTION
This PR groups some navbar menu items into a single dropdown "Discover SCS"/"SCS entdecken". Maybe someone can suggest a better wording?

![2021-10-06 21_32_02-About SCS _ Sovereign Cloud Stack](https://user-images.githubusercontent.com/29982899/136271268-0ff373ab-1d50-41c3-a155-6628394eb901.png)


