### PR TITLE
Set JEKYLL_ENV to development (for now)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,6 +29,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-new-gems-
     - uses: lemonarc/jekyll-action@1.0.0
+      env:
+        JEKYLL_ENV: development
     - uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete --exclude=/docs/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,11 +18,7 @@
 
   <title>{{ title }}</title>
   <meta property="og:title" content="{{title}}">
-  <meta property="og:image" content="{{page.image}}"/>
-  <meta property="og:description" content="{{page.description}}"/>
-  <meta property="og:url" content="{{ site.baseurl }}{% if page.url %}{{ page.url }}{% endif %}"/>
-  <meta property="og:locale" content="{% t site.lang %}"/>
-  
+
   <!-- Bootstrap core CSS -->
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl_root }}" />
   <!-- Favicon -->


### PR DESCRIPTION
When using `jekyll-action@1.0.0` the environment `JEKYLL_ENV=production` is set. However, this produces meta properties `og:image` with relative paths. This in turn leads to blank twitter cards. (see #185)

Signed-off-by: Eduard Itrich <eduard@itrich.net>