### PR TITLE
Switch to jekyll build action by @jeffreytse

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete --exclude=/docs/
-        path: _site/
+        path: build/
         remote_host: ${{ secrets[matrix.host] }}
         remote_port: ${{ secrets[matrix.port] }}
         remote_path: ${{ secrets[matrix.path] }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,14 +21,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      # Use GitHub Actions' cache to shorten build times and decrease load on servers
+    # Use GitHub Actions' cache to shorten build times and decrease load on servers
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-new-gems-
-    - uses: lemonarc/jekyll-action@1.0.0
+          ${{ runner.os }}-gems-
+    # Use GitHub Deploy Action to build and deploy to Github
+    - uses: jeffreytse/jekyll-deploy-action@v0.3.1
+      with:
+        provider: 'github'
+        token: ${{ secrets.GITHUB_TOKEN }} # It's your Personal Access Token(PAT)
+        repository: ''             # Default is current repository
+        branch: 'gh-pages'         # Default is gh-pages for github provider
+        jekyll_src: './'           # Default is root directory
+        jekyll_cfg: '_config.yml'  # Default is _config.yml
+        jekyll_baseurl: ''         # Default is according to _config.yml
+        bundler_ver: '>=0'         # Default is latest bundler version
+        cname: ''                  # Default is to not use a cname
+        actor: ''                  # Default is the GITHUB_ACTOR
+        pre_build_commands: ''     # Installing additional dependencies (Arch Linux)
     - uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete --exclude=/docs/


### PR DESCRIPTION
This PR switches to the more frequently used github action [jeffreytse/jekyll-deploy-action](https://github.com/jeffreytse/jekyll-deploy-action) which gives some more options (including pushing the rendered website to a specific branch).

We use the same action for [SovereignCloudStack/newsletter](https://github.com/SovereignCloudStack/newsletter).