### PR TITLE
Add page lot6a and corresponding site title translation

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -60,6 +60,7 @@ tenders:
     lot3: "Vergabepaket 3"
     lot4: "Vergabepaket 4"
     lot5: "Vergabepaket 5"
+    lot6a: "Vergabepaket 6a"
     lot6d: "Vergabepaket 6d"
     lot8: "Vergabepaket 8"
     lot10: "Vergabepaket 10"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -60,6 +60,7 @@ tenders:
     lot3: "Lot 3"
     lot4: "Lot 4"
     lot5: "Lot 5"
+    lot6a: "Lot 6a"
     lot6d: "Lot 6d"
     lot8: "Lot 8"
     lot10: "Lot 10"

--- a/_pages/tenders/lot6a.md
+++ b/_pages/tenders/lot6a.md
@@ -1,0 +1,7 @@
+---
+title_slug: tenders.title.lot6a
+layout: default
+permalink: /tenders/lot6a/
+---
+
+{% tf tenders/lot6a.md %}


### PR DESCRIPTION
Sorry, jekyll is kind of weird when it comes to internationalization. You first need to create a page under `_pages/` which in turn pulls in the translated content via `{% tf ... %}`. Moreover, the translation of the site title needs to be added seperately to `_i18n/de.yml` and `_i18n/en.yml`.