### PR TITLE
Avoid destroying antrag-bmwi/ subdir on deployment.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -44,7 +44,7 @@ jobs:
         pre_build_commands: ''     # Installing additional dependencies (Arch Linux)
     - uses: burnett01/rsync-deployments@5.2
       with:
-        switches: -avzr --delete --exclude=/docs/
+        switches: -avzr --delete --exclude=/docs/ --exclude=/antrag-bmwi
         path: build/
         remote_host: ${{ secrets[matrix.host] }}
         remote_port: ${{ secrets[matrix.port] }}


### PR DESCRIPTION
We pass -v some-directory:/usr/local/apache2/htdocs/antrag-bmwi to the docker run command.
So let's rather not have `rsync --delete` destroy this directory. We do protect the other mounted dir for the contributor guide successfully already, so copy this over.

Signed-off-by: Kurt Garloff <kurt@garloff.de>