### PR TITLE
Add hyperlink to bibliography items directly within title (as Wikipedia does)

### DIFF
--- a/_bibliography/references.bib
+++ b/_bibliography/references.bib
@@ -1,46 +1,34 @@
-@Book{ Oppenheim,
-	author = { Oppenheim, L. and Arnold Duncan McNair },
-	title = { International law / a treatise by L.Oppenheim. 4th ed. ed. by A.D.McNair },
-	edition = { 4th ed. },
-	publisher = { Longmans Lond },
-	pages = { 2 v. },
-	year = { 1926 },
-	type = { Book },
-	language = { English },
-	subjects = { International law. },
-	life-dates = { 1926 - 1928 },
-	catalogue-url = { https://nla.gov.au/nla.cat-vn853802 },
+@Book{Oppenheim,
+	author = {Oppenheim, Lassa},
+	title = {International Law. A Treatise. Volume I (of 2) Peace. Second Edition},
+	publisher = {Longmans, Green and Co.},
+	year = {1912},
+	language = {English},
 }
 
 @InCollection{PhilDan,
-	author       =	{Philpott, Daniel},
-	title        =	{{Sovereignty}},
-	booktitle    =	{The {Stanford} Encyclopedia of Philosophy},
-	editor       =	{Edward N. Zalta},
-	howpublished =	{\url{https://plato.stanford.edu/archives/fall2020/entries/sovereignty/}},
-	year         =	{2020},
-	edition      =	{{F}all 2020},
-	publisher    =	{Metaphysics Research Lab, Stanford University}
+	author = {Philpott, Daniel},
+	title = {<a href="https://plato.stanford.edu/archives/fall2020/entries/sovereignty/">Sovereignty</a>},
+	booktitle = {The {Stanford} Encyclopedia of Philosophy},
+	editor = {Edward N. Zalta},
+	year = {2020},
+	edition = {{F}all 2020},
+	publisher = {Metaphysics Research Lab, Stanford University}
 }
 
 @article{CouToupin,
 	author = {Stephane Couture and Sophie Toupin},
-	title ={What does the notion of “sovereignty” mean when referring to the digital?},
+	title = {<a href="https://doi.org/10.1177/1461444819865984">What does the notion of “sovereignty” mean when referring to the digital?</a>},
 	journal = {New Media \& Society},
 	volume = {21},
 	number = {10},
 	pages = {2305-2322},
 	year = {2019},
-	doi = {10.1177/1461444819865984},
-	URL = {https://doi.org/10.1177/1461444819865984},
-	eprint = {https://doi.org/10.1177/1461444819865984}
 }
 
 @article{RiehDir,
 	author = {Dirk Riehle},
-	doi = {doi:10.1515/itit.2013.9005},
-	url = {https://doi.org/10.1515/itit.2013.9005},
-	title = {The Unstoppable Rise of Open Source / Der Siegeszug von Open Source},
+	title = {<a href="https://doi.org/10.1515/itit.2013.9005">The Unstoppable Rise of Open Source / Der Siegeszug von Open Source</a>},
 	journal = {it - Information Technology},
 	number = {5},
 	volume = {55},
@@ -49,28 +37,24 @@
 }
 
 @proceedings{DigitalGipfel2018,
-	title={{Digitale Souveränität und Künstliche Intelligenz – Voraussetzungen, Verantwortlichkeiten und Handlungsempfehlungen}},
-	author={{Digital-Gipfel}},
-	url={https://www.de.digital/DIGITAL/Redaktion/DE/Digital-Gipfel/Download/2018/p2-digitale-souveraenitaet-und-kuenstliche-intelligenz.pdf},
-	year={2018},
-	publisher={{Plattform Innovative Digitalisierung der Wirtschaft: Fokusgruppe „Digitale Souveränität in einer vernetzten Gesellschaft“}}
+	title = {<a href="https://www.de.digital/DIGITAL/Redaktion/DE/Digital-Gipfel/Download/2018/p2-digitale-souveraenitaet-und-kuenstliche-intelligenz.pdf">Digitale Souveränität und Künstliche Intelligenz – Voraussetzungen, Verantwortlichkeiten und Handlungsempfehlungen</a>},
+	author = {{Digital-Gipfel}},
+	year = {2018},
+	publisher = {{Plattform Innovative Digitalisierung der Wirtschaft: Fokusgruppe „Digitale Souveränität in einer vernetzten Gesellschaft“}}
 }
 
 @book{acatech,
-	title={Digital Sovereignty: Status Quo and Perspectives},
-	author={Kagermann, Henning and Streibich, Karl-Heinz and Suder, Katrin},
-	isbn={9783968340111},
-	series={acatech Impuls},
-	url={https://www.acatech.de/publikation/digitale-souveraenitaet-status-quo-und-handlungsfelder/},
-	year={2021},
-	publisher={acatech - Deutsche Akademie der Technikwissenschaften}
+	title = {<a href="https://www.acatech.de/publikation/digitale-souveraenitaet-status-quo-und-handlungsfelder/">Digital Sovereignty: Status Quo and Perspectives</a>},
+	author = {Kagermann, Henning and Streibich, Karl-Heinz and Suder, Katrin},
+	isbn = {9783968340111},
+	series = {acatech Impuls},
+	year = {2021},
+	publisher = {acatech - Deutsche Akademie der Technikwissenschaften}
 }
 
 @book{eudps,
 	author = {{European Data Protection Supervisor}},
-	title = {EDPS public paper on outcome of own-initiative investigation into EU institutions’ use of Microsoft products and services},
+	title = {<a href="https://op.europa.eu/en/publication-detail/-/publication/ddc8842d-ca33-11ea-adf7-01aa75ed71a1/language-en">EDPS public paper on outcome of own-initiative investigation into EU institutions’ use of Microsoft products and services</a>},
 	publisher = {Publications Office},
-	year = {2020},
-	doi = {doi/10.2804/14519},
-	url = {https://op.europa.eu/en/publication-detail/-/publication/ddc8842d-ca33-11ea-adf7-01aa75ed71a1/language-en}
+	year = {2020}
 }


### PR DESCRIPTION
This isn't really the best solution, but according to the [issue in jekyll-scholar](https://github.com/inukshuk/jekyll-scholar/issues/30#issuecomment-657129593) there aren't many options. I moved the url to the title just as Wikipedia does. 

The blog post now looks good on mobile devices. Fixes #258 

Signed-off-by: Eduard Itrich <eduard@itrich.net>