### PR TITLE
Don't redirect back to /en/ if language is provided

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,7 +26,10 @@ layout: default
 	var referrer = document.referrer;
 	var landingPage = !referrer || referrer.indexOf(hostname) == -1;
 	
-	if (landingPage && (current_lang !== suitable_lang)) {
+	if (landingPage
+		&& (current_lang !== suitable_lang)
+		&& suitable_lang != "en")	// Don't redirect back to /en/ and keep provided language
+	{
   	window.location = '/' + suitable_lang + '/';
 	}
 </script>


### PR DESCRIPTION
As spotted by @fkr, the index page redirects to https://scs.community/en (which is not available) if landing directly on https://scs.community/de

This PR fixes this behaviour. A user that comes via https://scs.community/{{lang}} and has a browser with Englisch locales won't be redirected back. He'll stick to the initial provided language.

This bug was introduced by #254.

Signed-off-by: Eduard Itrich <eduard@itrich.net>