### PR TITLE
Add filters to the tender table

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -80,6 +80,11 @@ tenders:
     lot9c: "Penetration Testing"
     lot10: "SCS Zertifizierung"
     lot11: "Aufbau Serverhardware"
+  filter:
+    all: "Alle Ausschreibungen"
+    open: "Laufende Ausschreibungen"
+    upcoming: "Ausstehende Ausschreibungen"
+    closed: "Abgeschlossene Ausschreibungen"
 jobs:
   apply: "Jetzt bewerben"
   community-manager:

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -80,6 +80,11 @@ tenders:
     lot9c: "Penetration Testing"
     lot10: "SCS certification"
     lot11: "Server Hardware Installation"
+  filter:
+    all: "All tenders"
+    open: "Open tenders"
+    upcoming: "Upcoming tenders"
+    closed: "Closed tenders"
 jobs:
   apply: "Apply now"
   community-manager:

--- a/_pages/tenders.md
+++ b/_pages/tenders.md
@@ -10,6 +10,11 @@ redirect_from:
 
 {% tf tenders/tenders.md %}
 
+<button class="btn btn-sm rounded-pill bg-primary text-light" id="all">{% t tenders.filter.all %}</button>
+<button class="btn btn-sm rounded-pill bg-secondary text-light" id="open">{% t tenders.filter.open %}</button>
+<button class="btn btn-sm rounded-pill bg-secondary text-light" id="upcoming">{% t tenders.filter.upcoming %}</button> 
+<button class="btn btn-sm rounded-pill bg-secondary text-light" id="closed">{% t tenders.filter.closed %}</button> 
+
 <div class="table-responsive text-center">
 <table>
   <thead>
@@ -22,7 +27,7 @@ redirect_from:
   </thead>
   <tbody>
     {% for lot in site.tenders %}
-    <tr>
+    <tr class="lot {{lot.state}}">
       <td>{%- if lot.retry -%}—{%- else -%}{{lot.number}}{%- endif -%}</td>
       <td>{% t lot.title_slug %}</td>
       <td>
@@ -61,3 +66,18 @@ redirect_from:
   </tbody>
 </table>
 </div>
+
+<script>
+$(document).ready(function(){
+  $(".btn").on("click", function() {
+    $('.btn').addClass('bg-secondary').removeClass('bg-primary');
+    $(this).removeClass('bg-secondary').addClass('bg-primary');
+    if (this.id == "all") {
+      $('.lot').show();
+    } else {
+      $('.lot').hide();
+      $('.' + this.id).show();
+    }
+  });
+});
+</script>

--- a/_tenders/lot1.md
+++ b/_tenders/lot1.md
@@ -9,7 +9,7 @@ number: 1
 number_vh81: 1
 start_date: 2021-07-30
 closing_date: 2021-08-20
-state: closed # undefined, defined, open or closed
+state: closed # open, upcoming or closed
 ---
 
 {% tf tenders/lot1.md %}

--- a/_tenders/lot10-2.md
+++ b/_tenders/lot10-2.md
@@ -7,7 +7,7 @@ number_vh81: 10
 retry: 2
 start_date: 2022-01-12
 closing_date: 2022-01-27
-state: closed # undefined, defined, open or closed
+state: closed # open, upcoming or closed
 ---
 
 {% tf tenders/lot10.md %}

--- a/_tenders/lot10-3.md
+++ b/_tenders/lot10-3.md
@@ -7,7 +7,7 @@ number_vh81: 10
 retry: 3
 start_date: 2022-06-24
 closing_date: 2022-07-19 T12:00+01:00
-state: open # undefined, defined, open or closed
+state: open # open, upcoming or closed
 contracting_portal: https://www.dtvp.de/Satellite/notice/CXP4YV7R2BL
 ---
 

--- a/_tenders/lot10.md
+++ b/_tenders/lot10.md
@@ -9,7 +9,7 @@ number: 15
 number_vh81: 10
 start_date: 2021-11-12
 closing_date: 2021-12-07
-state: closed # undefined, defined, open or closed
+state: closed # open, upcoming or closed
 ---
 
 {% tf tenders/lot10.md %}

--- a/_tenders/lot11.md
+++ b/_tenders/lot11.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 16
 number_vh81: 11
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---

--- a/_tenders/lot2.md
+++ b/_tenders/lot2.md
@@ -7,7 +7,7 @@ redirect_from:
    
 number: 2
 number_vh81: 2
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---
 
 {% tf tenders/lot2.md %}

--- a/_tenders/lot3.md
+++ b/_tenders/lot3.md
@@ -7,7 +7,7 @@ redirect_from:
    
 number: 3
 number_vh81: 3
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---
 
 {% tf tenders/lot3.md %}

--- a/_tenders/lot4.md
+++ b/_tenders/lot4.md
@@ -7,7 +7,7 @@ redirect_from:
    
 number: 4
 number_vh81: 4
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---
 
 {% tf tenders/lot4.md %}

--- a/_tenders/lot5.md
+++ b/_tenders/lot5.md
@@ -7,7 +7,7 @@ redirect_from:
    
 number: 5
 number_vh81: 5
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---
 
 {% tf tenders/lot5.md %}

--- a/_tenders/lot6a.md
+++ b/_tenders/lot6a.md
@@ -4,7 +4,7 @@ layout: default
 
 number: 6
 number_vh81: 6a
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---
 
 {% tf tenders/lot6a.md %}

--- a/_tenders/lot6b.md
+++ b/_tenders/lot6b.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 7
 number_vh81: 6b
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---

--- a/_tenders/lot6c.md
+++ b/_tenders/lot6c.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 8
 number_vh81: 6c
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---

--- a/_tenders/lot6d.md
+++ b/_tenders/lot6d.md
@@ -6,7 +6,7 @@ number: 9
 number_vh81: 6d
 start_date: 2021-12-22
 closing_date: 2022-01-19
-state: closed # undefined, defined, open or closed
+state: closed # open, upcoming or closed
 ---
 
 {% tf tenders/lot6d.md %}

--- a/_tenders/lot6e.md
+++ b/_tenders/lot6e.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 10
 number_vh81: 6e
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---

--- a/_tenders/lot8.md
+++ b/_tenders/lot8.md
@@ -9,7 +9,7 @@ number: 11
 number_vh81: 8
 start_date: 2022-02-28
 closing_date: 2022-03-22
-state: closed # undefined, defined, open or closed
+state: closed # open, upcoming or closed
 ---
 
 {% tf tenders/lot8.md %}

--- a/_tenders/lot9a.md
+++ b/_tenders/lot9a.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 12
 number_vh81: 9a
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---

--- a/_tenders/lot9b.md
+++ b/_tenders/lot9b.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 13
 number_vh81: 9b
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---

--- a/_tenders/lot9c.md
+++ b/_tenders/lot9c.md
@@ -4,5 +4,5 @@ layout: default
 
 number: 14
 number_vh81: 9c
-state: undefined # undefined, defined, open or closed
+state: upcoming # open, upcoming or closed
 ---


### PR DESCRIPTION
As discussed today, we need a simple way to see all open tenders. I therefore added some filters to the table to toggle between the different states of the tenders. Are you missing something, @fkr? Does this PR solve the unclairity of currently running tenders?