### PR TITLE
Switch to new asset pipeline in this old blog posting

### DIFF
--- a/_i18n/de/_posts/blog/2022-05-09-meet-scs.md
+++ b/_i18n/de/_posts/blog/2022-05-09-meet-scs.md
@@ -1,0 +1,1 @@
+../../../en/_posts/blog/2022-05-09-meet-scs.md

--- a/_i18n/en/_posts/blog/2022-05-09-meet-scs.md
+++ b/_i18n/en/_posts/blog/2022-05-09-meet-scs.md
@@ -26,12 +26,12 @@ will be available to answer your questions about SCS.
 <div class="row my-3">
   <div class="col-6">
     <a href="https://www.cloudexpoeurope.de/konferenzprogramm-2022/using-sovereign-cloud-stack-to-achieve-digital-sovereignty">
-      <img src="{{ "/assets/images/events/cee2022/kurt.png" | prepend: site.baseurl_root }}" class="w-75 rounded mx-auto d-block" alt="Using Sovereign Cloud Stack to Achieve Digital Sovereignty">
+      {% asset 'events/cee2022/kurt.png' vips:format=".webp" class="w-75 rounded mx-auto d-block" alt="Using Sovereign Cloud Stack to Achieve Digital Sovereignty" %}
     </a>
   </div>
   <div class="col-6">
     <a href="https://www.cloudexpoeurope.de/konferenzprogramm-2022/digital-sovereignty-and-the-cloud-everything-is-at-stake">
-      <img src="{{ "/assets/images/events/cee2022/peter.png" | prepend: site.baseurl_root }}" class="w-75 rounded mx-auto d-block" alt="Using Sovereign Cloud Stack to Achieve Digital Sovereignty">
+      {% asset 'events/cee2022/peter.png' vips:format=".webp" class="w-75 rounded mx-auto d-block" alt="Digital sovereignty and the cloud - Everything is at stake" %}
     </a>
   </div>
 </div>
@@ -49,7 +49,7 @@ The agenda features loads of interesting talks, among them quite a few from our 
 <div class="row my-3 justify-content-center">
   <div class="col-8">
     <a href="https://openinfra.dev/summit">
-      <img src="{{ "/assets/images/events/oif2022/all.png" | prepend: site.baseurl_root }}" class="w-75 rounded mx-auto d-block" alt="Using Sovereign Cloud Stack to Achieve Digital Sovereignty">
+      {% asset 'events/oif2022/all.png' vips:format=".webp" class="w-75 rounded mx-auto d-block" alt="Sovereign Cloud Stack at OpenInfra Summit 2022" %}
     </a>
   </div>
 </div>


### PR DESCRIPTION
I just randomly checked some old blog postings and found that the posting `2022-05-09-meet-scs.md` does include some images without using the new asset pipeline.