### PR TITLE
Add short links to technical release notes on GitHub

### DIFF
--- a/_pages/shortlinks/r0.md
+++ b/_pages/shortlinks/r0.md
@@ -1,0 +1,6 @@
+---
+title_slug: Release Notes for SCS Release 0
+permalink: /release-notes-r0/
+redirect_to:
+   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md
+---

--- a/_pages/shortlinks/r0.md
+++ b/_pages/shortlinks/r0.md
@@ -1,5 +1,5 @@
 ---
-title_slug: Release Notes for SCS Release 0
+title: Release Notes for SCS Release 0
 permalink: /release-notes-r0/
 redirect_to:
    - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md

--- a/_pages/shortlinks/r1.md
+++ b/_pages/shortlinks/r1.md
@@ -1,0 +1,6 @@
+---
+title_slug: Release Notes for SCS Release 1
+permalink: /release-notes-r1/
+redirect_to:
+   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md
+---

--- a/_pages/shortlinks/r1.md
+++ b/_pages/shortlinks/r1.md
@@ -1,5 +1,5 @@
 ---
-title_slug: Release Notes for SCS Release 1
+title: Release Notes for SCS Release 1
 permalink: /release-notes-r1/
 redirect_to:
    - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md

--- a/_pages/shortlinks/r2.md
+++ b/_pages/shortlinks/r2.md
@@ -1,0 +1,6 @@
+---
+title_slug: Release Notes for SCS Release 2
+permalink: /release-notes-r2/
+redirect_to:
+   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md
+---

--- a/_pages/shortlinks/r2.md
+++ b/_pages/shortlinks/r2.md
@@ -1,5 +1,5 @@
 ---
-title_slug: Release Notes for SCS Release 2
+title: Release Notes for SCS Release 2
 permalink: /release-notes-r2/
 redirect_to:
    - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md

--- a/_pages/shortlinks/r3.md
+++ b/_pages/shortlinks/r3.md
@@ -1,5 +1,5 @@
 ---
-title_slug: Release Notes for SCS Release 3
+title: Release Notes for SCS Release 3
 permalink: /release-notes-r3/
 redirect_to:
    - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release3.md

--- a/_pages/shortlinks/r3.md
+++ b/_pages/shortlinks/r3.md
@@ -1,0 +1,6 @@
+---
+title_slug: Release Notes for SCS Release 3
+permalink: /release-notes-r3/
+redirect_to:
+   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release3.md
+---


### PR DESCRIPTION
This PR adds some handy short links to our (technical) release notes on GitHub: 
<https://scs.community/release-notes-r2>, <https://scs.community/release-notes-r3>, etc.

This can be used for our press release around the upcoming R3, for instance.