### PR TITLE
Clarify that we already have well-established offerings ...

### DIFF
--- a/_i18n/de/_posts/announcements/2022-09-21-release3.md
+++ b/_i18n/de/_posts/announcements/2022-09-21-release3.md
@@ -115,10 +115,12 @@ in die Lage zu versetzen, auch täglich ein Upgrade der Umgebungen durchführen 
 
 ## Dritter Public-Cloud-Provider setzt auf Sovereign Cloud Stack
 
-Nach [OSISM](https://osism.tech/) und [PlusServer](https://www.plusserver.com/)
-setzt nun auch [Wavecon](https://www.wavecon.de/) – eine 100%ige Tochter
+Mit den Public Clouds von [OSISM](https://osism.tech/) und [PlusServer](https://www.plusserver.com/)
+exisitieren bereits gute Sovereign Cloud Stack Angebote vor allem für Unternehmen.
+Nun setzt auch [Wavecon](https://www.wavecon.de/) – eine 100%ige Tochter
 der [noris network AG](https://www.noris.de/) – auf die SCS-Referenzimplementierung zum Aufbau und Betrieb
-einer vollständig offenen, standardisierten souveränen Public-Cloud. Mit dem [Wavestack](https://www.noris.de/wavestack-cloud-demo)
+einer vollständig offenen, standardisierten souveränen Public-Cloud und stärkt
+diesen Bereich somit. Mit dem [Wavestack](https://www.noris.de/wavestack-cloud-demo)
 bringt damit zeitgleich zum Release 3 der dritte Public-Cloud-Provider sein Angebot
 an den Markt.
 

--- a/_i18n/en/_posts/announcements/2022-09-21-release3.md
+++ b/_i18n/en/_posts/announcements/2022-09-21-release3.md
@@ -115,11 +115,13 @@ their environments on a daily basis.
 
 ## Third public cloud provider uses Sovereign Cloud Stack
 
-After [OSISM](https://osism.tech/) and [PlusServer](https://www.plusserver.com/)
-now also [Wavecon](https://www.wavecon.de/) - a 100% subsidiary of the
+With the public clouds from [OSISM](https://osism.tech/) and [PlusServer](https://www.plusserver.com/),
+there are already good SCS offerings primarily primarily targeted at the private sector.
+Now also [Wavecon](https://www.wavecon.de/) - a 100% subsidiary of the
 [noris network AG](https://www.noris.de/) - relies on the SCS reference
 implementation for the setup and operation of a fully open, standardized sovereign
-public cloud. With [Wavestack](https://www.noris.de/wavestack-cloud-demo)
+public cloud, this way further strengthening the coverage and choice for companies.
+With [Wavestack](https://www.noris.de/wavestack-cloud-demo)
 the third public cloud provider launches its new offering simultaneously to the
 release of SCS R3.
 


### PR DESCRIPTION
... primarily targeted at the private sector.

This to avoid the first section of the PR to trigger the misconception that SCS is primarily targeted at (and only good enough for) the public sector IT requirements.

Signed-off-by: Kurt Garloff <kurt@garloff.de>