### PR TITLE
Add a site to display all security advisories

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -12,7 +12,7 @@ nav:
   opensource: "Open Source"
   partners: "Servicepartner"
   news: "Neuigkeiten"
-  security: "Sicherheitsinformationen"
+  security: "Sicherheitshinweise und Empfehlungen"
   jobs: "Offene Stellen"
   tenders: "Ausschreibungen"
   contribute: "Zu SCS beitragen"

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -12,6 +12,7 @@ nav:
   opensource: "Open Source"
   partners: "Servicepartner"
   news: "Neuigkeiten"
+  security: "Sicherheitsinformationen"
   jobs: "Offene Stellen"
   tenders: "Ausschreibungen"
   contribute: "Zu SCS beitragen"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -12,6 +12,7 @@ nav:
   opensource: "Open source"
   partners: "Service partners"
   news: "News"
+  security: "Security Advisories"
   jobs: "Open positions"
   tenders: "Public tenders"
   contribute: "Contribute to SCS"

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+<h2 class="mb-3"><small><i class="fa fa-exclamation-triangle me-1"></i> {% t nav.security %}</small></h2>
+<div class="list-group mb-4">
+{% assign sorted = site.posts | sort: 'date' | reverse %}
+{% for post in sorted %}
+{% if post.category contains 'security' %}
+	<a href="{{ site.baseurl }}{{post.url}}" class="list-group-item list-group-item-action flex-column align-items-start">
+	<div class="d-flex flex-row">
+		{% include news/blog_avatars.html %}
+		<div class="d-flex w-100 flex-column ms-3 my-auto">
+			<div class="d-flex w-100 justify-content-between">
+				<h5 class="mb-1" style="font-size:.875em">{{post.author | join: ", "}}</h5>
+				<small class="ms-2">{% include date.html date=post.date %}</small>
+			</div>
+		<p class="mb-1">{{post.title}}</p>
+	</div>
+	</div>
+	</a>
+{% endif %}
+{% endfor %}
+</div>

--- a/_pages/security.md
+++ b/_pages/security.md
@@ -1,0 +1,5 @@
+---
+title_slug: nav.security
+layout: security
+permalink: /security/
+---


### PR DESCRIPTION
This site displays all blog posts within the category `security` under `https://scs.community/security`. This should be added to https://github.com/SovereignCloudStack/.github/pull/9

![image](https://user-images.githubusercontent.com/29982899/199660322-bc57f59a-af99-40a8-8972-ba7f24f49197.png)


Signed-off-by: Eduard Itrich <eduard@itrich.net>