### PR TITLE
Fix short link of release notes

### DIFF
--- a/_pages/shortlinks/r0.md
+++ b/_pages/shortlinks/r0.md
@@ -2,5 +2,5 @@
 title: Release Notes for SCS Release 0
 permalink: /release-notes-r0/
 redirect_to:
-   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md
+   - https://github.com/SovereignCloudStack/release-notes/blob/main/Release0.md
 ---

--- a/_pages/shortlinks/r1.md
+++ b/_pages/shortlinks/r1.md
@@ -2,5 +2,5 @@
 title: Release Notes for SCS Release 1
 permalink: /release-notes-r1/
 redirect_to:
-   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md
+   - https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md
 ---

--- a/_pages/shortlinks/r2.md
+++ b/_pages/shortlinks/r2.md
@@ -2,5 +2,5 @@
 title: Release Notes for SCS Release 2
 permalink: /release-notes-r2/
 redirect_to:
-   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md
+   - https://github.com/SovereignCloudStack/release-notes/blob/main/Release2.md
 ---

--- a/_pages/shortlinks/r3.md
+++ b/_pages/shortlinks/r3.md
@@ -2,5 +2,5 @@
 title: Release Notes for SCS Release 3
 permalink: /release-notes-r3/
 redirect_to:
-   - https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release3.md
+   - https://github.com/SovereignCloudStack/release-notes/blob/main/Release3.md
 ---


### PR DESCRIPTION
This addresses #536. We still need to go through the repository and sed all occurrences of the old release notes URI.