### PR TITLE
linkfix ReleaseX.md

### DIFF
--- a/_i18n/de/_posts/announcements/2021-07-15-release0.md
+++ b/_i18n/de/_posts/announcements/2021-07-15-release0.md
@@ -49,7 +49,7 @@ Testbed vertraut sind und jetzt den nächsten Schritt gehen wollen.
 Wir haben in den vergangenen Tage eine Menge Dokumentation auf den aktuellen
 Stand gebracht. Nutzen Sie unser [github Docs](https://github.com/SovereignCloudStack/Docs/)
 repository als Einstiegspunkt. Für R0 gibt es
-[spezifische Release Notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md).
+[spezifische Release Notes](https://github.com/SovereignCloudStack/release-notes/blob/main/Release0.md).
 Die Dokumente sind natürlich auch von unserer ["SCS nutzen"]({{ site.baseurl }}/get) Seite
 in unserer [Webpräsenz]({{ site.baseurl }}) verlinkt.
 

--- a/_i18n/de/_posts/announcements/2021-10-05-release1.md
+++ b/_i18n/de/_posts/announcements/2021-10-05-release1.md
@@ -12,7 +12,7 @@ Nach dem im Juli freigegebenen Release R0 mit Fokus auf die Installation einer [
 
 Grundlage von R1 bildet unter anderem das [OpenStack Wallaby Release](https://releases.openstack.org/wallaby/), [Kubernetes in der Version v1.21.x](https://github.com/kubernetes/kubernetes/releases) sowie die [Kubernetes Cluster API in Version v0.4](https://github.com/kubernetes-sigs/cluster-api/releases).
 
-Die [vollständigen Release-Informationen](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md) inklusive technischen Details sind im [zentralen Docs Repository](https://github.com/SovereignCloudStack/Docs) des SCS-Projektes auf GitHub zu finden.
+Die [vollständigen Release-Informationen](https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md) inklusive technischen Details sind im [zentralen Docs Repository](https://github.com/SovereignCloudStack/Docs) des SCS-Projektes auf GitHub zu finden.
 
 ## Kubernetes Cluster als Self-Service dank Cluster API
 

--- a/_i18n/de/_posts/announcements/2022-03-22-release2.md
+++ b/_i18n/de/_posts/announcements/2022-03-22-release2.md
@@ -96,7 +96,7 @@ Federation Services (GXFS) notwendig sind, wurden fertiggestellt. Mit den Gaia-X
 Federation Services sollen die unterschiedlichen Gaia-X-Dienste verknüpft werden.
 Damit wurde ein ganz wesentlicher Meilenstein von SCS für Gaia-X erreicht.
 
-Die [vollständigen Release Notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md)
+Die [vollständigen Release Notes](https://github.com/SovereignCloudStack/release-notes/blob/main/Release2.md)
 sind ab Mittwoch auf GitHub unter 
 <https://github.com/SovereignCloudStack/Docs/>
 zu finden.

--- a/_i18n/de/use.md
+++ b/_i18n/de/use.md
@@ -28,7 +28,7 @@ auf unser
 [github SCS Docs](https://github.com/SovereignCloudStack/Docs/)
 Repository.
 
-Am 15.7.2021 haben wir [Release 0]({{ site.baseurl }}/2021/07/15/release0) freigegeben.
+Am 15.7.2021 haben wir [Release 0](https://github.com/SovereignCloudStack/release-notes/blob/main/Release0.md) freigegeben.
 
 Am 29.9.2021 haben wir [Release 1](https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md) freigegeben.
 

--- a/_i18n/de/use.md
+++ b/_i18n/de/use.md
@@ -30,11 +30,11 @@ Repository.
 
 Am 15.7.2021 haben wir [Release 0]({{ site.baseurl }}/2021/07/15/release0) freigegeben.
 
-Am 29.9.2021 haben wir [Release 1](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md) freigegeben.
+Am 29.9.2021 haben wir [Release 1](https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md) freigegeben.
 
-Am 23.3.2022 haben wir [Release 2](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md) freigegeben.
+Am 23.3.2022 haben wir [Release 2](https://github.com/SovereignCloudStack/release-notes/blob/main/Release2.md) freigegeben.
 
-Am 21.9.2022 haben wir [Release 3](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release3.md) freigegeben.
+Am 21.9.2022 haben wir [Release 3](https://github.com/SovereignCloudStack/release-notes/blob/main/Release3.md) freigegeben.
 
 ## SCS und OSISM
 

--- a/_i18n/en/_posts/announcements/2021-07-15-release0.md
+++ b/_i18n/en/_posts/announcements/2021-07-15-release0.md
@@ -46,7 +46,7 @@ with SCS via testbed already and want to move to the next stage.
 We have updated a lot of documents in the last days. Use our
 [github Docs](https://github.com/SovereignCloudStack/Docs/) as entry point.
 There are specific
-[release notes for R0](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md).
+[release notes for R0](https://github.com/SovereignCloudStack/release-notes/blob/main/Release0.md).
 You can of course also find this from the ["Get SCS"]({{ site.baseurl }}/get)
 page from our [web site]({{ site.baseurl }}).
 

--- a/_i18n/en/_posts/announcements/2021-10-05-release1.md
+++ b/_i18n/en/_posts/announcements/2021-10-05-release1.md
@@ -12,7 +12,7 @@ After R0 has been released in July and focused on the installation of a [test en
 
 The newest release R1 includes the [OpenStack Wallaby Release](https://releases.openstack.org/wallaby/), [Kubernetes version v1.21.x](https://github.com/kubernetes/kubernetes/releases), and the [Kubernetes Cluster API version v0.4](https://github.com/kubernetes-sigs/cluster-api/releases).
 
-The [full release notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md) including technical details can be found in the [central docs repository](https://github.com/SovereignCloudStack/Docs) of the SCS project on GitHub.
+The [full release notes](https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md) including technical details can be found in the [central docs repository](https://github.com/SovereignCloudStack/Docs) of the SCS project on GitHub.
 
 ## Kubernetes cluster as self-service thanks to cluster API
 

--- a/_i18n/en/_posts/announcements/2022-03-22-release2.md
+++ b/_i18n/en/_posts/announcements/2022-03-22-release2.md
@@ -92,7 +92,7 @@ have been completed. The Gaia-X Federation Services will allow to connect the
 various Gaia-X services. Thus, a very important milestone of SCS for Gaia-X has
 been reached.
 
-The [full release notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md)
+The [full release notes](https://github.com/SovereignCloudStack/release-notes/blob/main/Release2.md)
 will be available on GitHub at <https://github.com/SovereignCloudStack/Docs/>
 as of Wednesday.
 

--- a/_i18n/en/_posts/blog/2022-03-23-r2-and-future-directions.md
+++ b/_i18n/en/_posts/blog/2022-03-23-r2-and-future-directions.md
@@ -12,7 +12,7 @@ about:
 
 ## Welcome Release 2
 
-Today we're [releasing the R2](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md) of the reference implementation of the Sovereign
+Today we're [releasing the R2](https://github.com/SovereignCloudStack/release-notes/blob/main/Release2.md) of the reference implementation of the Sovereign
 Cloud Stack. Our release announcement covers the many aspects of this release
 in detail. These range from our work on integrating the Kubernetes Cluster API,
 many improvements that focus on the operator experience up to items that help

--- a/_i18n/en/use.md
+++ b/_i18n/en/use.md
@@ -23,7 +23,7 @@ and contribute to it, we refer you to our
 [Github SCS Docs](https://github.com/SovereignCloudStack/Docs/)
 repository.
 
-On Jul 15, 2021 we have published [Release 0]({{ site.baseurl }}/2021/07/15/release0).
+On Jul 15, 2021 we have published [Release 0](https://github.com/SovereignCloudStack/release-notes/blob/main/Release0.md).
 
 On Sep 29, 2021 we have published [Release 1](https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md).
 

--- a/_i18n/en/use.md
+++ b/_i18n/en/use.md
@@ -25,11 +25,11 @@ repository.
 
 On Jul 15, 2021 we have published [Release 0]({{ site.baseurl }}/2021/07/15/release0).
 
-On Sep 29, 2021 we have published [Release 1](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md).
+On Sep 29, 2021 we have published [Release 1](https://github.com/SovereignCloudStack/release-notes/blob/main/Release1.md).
 
-On Mar 23, 2022 we have published [Release 2](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md).
+On Mar 23, 2022 we have published [Release 2](https://github.com/SovereignCloudStack/release-notes/blob/main/Release2.md).
 
-On Sep 21, 2022 we have published [Release 3](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release3.md).
+On Sep 21, 2022 we have published [Release 3](https://github.com/SovereignCloudStack/release-notes/blob/main/Release3.md).
 
 ## SCS and OSISM
 


### PR DESCRIPTION
fixed links to https://github.com/SovereignCloudStack/release-notes/ in /*/use.md

I did not touch link in blogposts:

```
$ grep -ir https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/
_i18n/en/_posts/announcements/2021-07-15-release0.md:[release notes for R0](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md).
_i18n/en/_posts/announcements/2022-03-22-release2.md:The [full release notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md)
_i18n/en/_posts/announcements/2021-10-05-release1.md:The [full release notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md) including technical details can be found in the [central docs repository](https://github.com/SovereignCloudStack/Docs) of the SCS project on GitHub.
_i18n/en/_posts/blog/2022-03-23-r2-and-future-directions.md:Today we're [releasing the R2](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md) of the reference implementation of the Sovereign
_i18n/de/_posts/announcements/2021-07-15-release0.md:[spezifische Release Notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release0.md).
_i18n/de/_posts/announcements/2022-03-22-release2.md:Die [vollständigen Release Notes](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release2.md)
_i18n/de/_posts/announcements/2021-10-05-release1.md:Die [vollständigen Release-Informationen](https://github.com/SovereignCloudStack/Docs/blob/main/Release-Notes/Release1.md) inklusive technischen Details sind im [zentralen Docs Repository](https://github.com/SovereignCloudStack/Docs) des SCS-Projektes auf GitHub zu finden.
klml@theimp:~/devel/website-scs$ 
```

Do you want me to fix these links too?