### PR TITLE
Fix broken links

### DIFF
--- a/_data/news_de.yml
+++ b/_data/news_de.yml
@@ -112,7 +112,7 @@
 - date: "2020-09-07"
   publisher: "nerdzoom"
   title: "NRDZM119: GAIA-X & Sovereign Cloud Stack"
-  link: "https://nerdzoom.de/nrdzm119-gaia-x-sovereign-cloud-stack/"
+  link: "https://techniktechnik.de/?podcast=nrdzm119-gaia-x-sovereign-cloud-stack"
 
 - date: "2020-08-28"
   publisher: "c't – magazin für computertechnik"
@@ -128,11 +128,6 @@
   publisher: "heise online"
   title: "Sovereign Cloud Stack: Auf dem Weg zur freien europäischen Cloud"
   link: "https://www.heise.de/news/Sovereign-Cloud-Stack-Auf-dem-Weg-zur-freien-europaeischen-Cloud-4839395.html"
-
-- date: "2020-07-09"
-  publisher: "WDR 5 Profit"
-  title: "Podcast vom 09.07.2020"
-  link: "https://www1.wdr.de/mediathek/audio/wdr5/wdr5-profit/audio-exporteinbruch---budelmann-electronic----siemens----stadtgemuese--100.html"
 
 - date: "2020-07-01"
   publisher: "Der Tagesspiegel"


### PR DESCRIPTION
* Fix broken link to Nerdzoom podcast
* Remove WDR 5 podcast as there is no more public ressource that we can link to