### PR TITLE
Fix deployment error for gh-pages

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -22,7 +22,10 @@ jobs:
       with:
         jekyll_src: "."
         jekyll_env: production
-        pre_build_commands: "apk add --update vips uglify-js"
+        # contemporary workaround for deploying on GH Pages, see: https://github.com/orgs/community/discussions/55820#discussioncomment-5948453
+        pre_build_commands: |
+          "apk add --update vips uglify-js"
+          git config --global http.version HTTP/1.1; apk fetch git-lfs
         build_only: false
         token: ${{ secrets.GITHUB_TOKEN }}
         target_branch: gh-pages


### PR DESCRIPTION
Currently the website does build successfully on new commit on `main`, but doesn't deploy on `gh-pages` branch. The Error in every action is:

```
error: RPC failed; HTTP 408 curl 18 HTTP/2 stream 7 was reset
send-pack: unexpected disconnect while reading sideband packet
fatal: the remote end hung up unexpectedly
```
see in the last Actions:

* https://github.com/SovereignCloudStack/website/actions/runs/5023220293/jobs/9007573763#step:6:1500
* https://github.com/SovereignCloudStack/website/actions/runs/5014464184/jobs/8992048230#step:6:1500

This is also being discussed in the following GitHub discussion: https://github.com/orgs/community/discussions/55820#discussioncomment-5948453

It seems that there is an error on the GitHub Pages since yesterday affecting many users.

This PR is adding a contemporary fix in the gh-pages action suggested by: https://github.com/orgs/community/discussions/55820#discussioncomment-5946136 