### PR TITLE
Feat/summit slides

### DIFF
--- a/_data/conferences_de.yml
+++ b/_data/conferences_de.yml
@@ -72,3 +72,9 @@
   title: "Sovereign Cloud Stack - Collaboration over Competition"
   details: "Felix Kronlage-Dammers"
   link: "https://www.youtube.com/watch?v=tAW0gIRlROQ"
+
+- date: "2023-05-23"
+  event: "SCS Summit 2023"
+  title: "Sovereign Cloud Stack Summit 2023"
+  details: "Verschiedene"
+  link: "https://scs.community/summit/"

--- a/_data/summit2023-talks.yml
+++ b/_data/summit2023-talks.yml
@@ -1,4 +1,5 @@
 - title: "Registrierung"
+  title_en: "Registration"
   day: 1
   start: "12:00"
   end: "13:00"
@@ -9,6 +10,7 @@
   description: ""
 
 - title: "Begrüßung durch das SCS Team"
+  title_en: "Welcome from the SCS team (DE)"
   day: 1
   start: "13:00"
   end: "13:10"
@@ -17,8 +19,10 @@
   avatar:
     - "SCS_logo.png"
   description: "Dr. Manuela Urban, COO SCS, OSB Alliance e.V.; Miriam Seyffarth, Leiterin Politische Kommunikation, OSB Alliance e.V. "
+  description_en: "Dr. Manuela Urban, COO SCS, OSB Alliance e.V.; Miriam Seyffarth, Head of Political Communication, OSB Alliance e.V. "
 
 - title: "Begrüßung durch die OSBA"
+  title_en: "Welcome by the OSBA (DE)"
   day: 1
   start: "13:10"
   end: "13:15"
@@ -27,8 +31,10 @@
   avatar:
     - "SCS_logo.png"
   description: "Milisav Radmanic, Vorstandsmitglied, OSB Alliance e.V."
+  description_en: "Milisav Radmanic, Member of the executive board, OSB Alliance e.V."
 
 - title: "Grußwort des BMWK"
+  title_en: "Welcome note from the BMWK (DE)"
   day: 1
   start: "13:15"
   end: "13:30"
@@ -37,8 +43,10 @@
   avatar:
     - "SCS_logo.png"
   description: "Ernst Stöckl-Pukall, Leiter Referat Digitalisierung & Industrie 4.0, Bundesministerium für Wirtschaft und Klimaschutz"
+  description_en: "Ernst Stöckl-Pukall, Head of Section Digitalization & Industry 4.0, German Ministry for Economic Affairs and Climate Action"
 
 - title: "Die Bedeutung von Digitaler Souveränität für Innovation, Freiheit und Demokratie"
+  title_en: "The relevance of Digital Sovereignty for innovation, freemdom, and democracy (DE)"
   day: 1
   start: "13:30"
   end: "14:15"
@@ -47,8 +55,10 @@
   avatar:
     - "SCS_logo.png"
   description: "Rafael Laguna de La Vera, Direktor der Bundesagentur für Sprunginnovationen SPRIND"
+  description_en: "Rafael Laguna de La Vera, Director of the Federal Agency for Disruptive Innovation SPRIND"
 
 - title: "Warum digitale Souveränität wichtig für Europa (die europäische Wirtschaft) ist"
+  title_en: "Why digital sovereignty matters for Europe (and the European economy) (DE)"
   day: 1
   start: "14:15"
   end: "15:00"
@@ -68,7 +78,8 @@
     - "SCS_logo.png"
   description: ""
 
-- title: "„Internationale Perspektiven auf Digitale Souveränität und Open Source: GovStack und das Netzwerk digital.global“"
+- title: "Internationale Perspektiven auf Digitale Souveränität und Open Source: GovStack und das Netzwerk digital.global"
+  title_en: "International perspective on Digital Sovereignty and Open Source: GovStack and the network digital.global (DE)"
   day: 1
   start: "15:50"
   end: "16:15"
@@ -79,6 +90,7 @@
   description: "Martin Wimmer, Chief Digital Officer, Bundesministerium für wirtschaftliche Zusammenarbeit und Entwicklung"
 
 - title: "Cloud Transformation im öffentlichen Sektor und der Aufbau der Deutschen Verwaltungscloud"
+  title_en: "Cloud transformation in the public sector and setting up the German Adminstrative Cloud (DE)"
   day: 1
   start: "16:15"
   end: "16:40"
@@ -88,7 +100,7 @@
     - "SCS_logo.png"
   description: "Martin Schallbruch, Vorsitzender des Vorstands der govdigital eG"
 
-- title: "The vision of one platform - standardized, built and operated by many"
+- title: "The vision of one platform - standardized, built and operated by many (EN)"
   day: 1
   start: "16:40"
   end: "17:05"
@@ -100,6 +112,7 @@
   slides: "https://scs.sovereignit.de/nextcloud/s/ydXyXSmN88WL8FS"
   
 - title: "Bauen Sie Ihren eigenen Hyperscaler: Wie Sie eine souveräne Private Cloud auf Basis des Souvereign Cloud Stack aufbauen"
+  title_en: "Build your own hyperscaler: How to build your own sovereign private cloud based on SCS (DE)"
   day: 1
   start: "17:05"
   end: "17:30"
@@ -110,6 +123,7 @@
   description: "Christian Wolter, Key Account Manager, B1 Systems GmbH"
 
 - title: "So wird Verwaltung digital souverän - Open Source als Weg aus der Abhängigkeit"
+  title_en: "How to make adminsitration digitally sovereign - Open Source to escape the dependence (DE)"
   day: 1
   start: "17:30"
   end: "17:55"
@@ -120,6 +134,7 @@
   description: "Silke Tessmann-Storch, Vorständin Lösungen, dataport A.ö.R."
 
 - title: "Zusammenfassung und Ausblick"
+  title_en: "Summary and outlook (DE)"
   day: 1
   start: "17:55"
   end: "18:00"
@@ -130,6 +145,7 @@
   description: "Miriam Seyffarth, Leiterin Politische Kommunikation, OSB Alliance e.V."
 
 - title: "Ausklang auf der Dachterasse"
+  title_en: "Social Event on the roof terrace"
   day: 1
   start: "18:00"
   end: "22:00"
@@ -140,6 +156,7 @@
   description: ""
 
 - title: "Registrierung"
+  title_en: "Registration"
   day: 2
   start: "08:00"
   end: "09:00"
@@ -150,6 +167,7 @@
   description: ""
 
 - title: "Welcome und Rückblick auf Tag 1"
+  title_en: "Welcome and review of day 1 (DE)"
   day: 2
   start: "09:00"
   end: "09:10"
@@ -160,6 +178,7 @@
   description: "Miriam Seyffarth, Leiterin Politische Kommunikation, OSB Alliance e.V."
 
 - title: "Die strategische Relevanz von SCS als Praxisbeispiel digitaler Transformation"
+  title_en: "The strategic relevance of SCS as real life example for digital transformation (DE)"
   day: 2
   start: "09:10"
   end: "09:30"
@@ -170,6 +189,7 @@
   description: "Christian Schmitz, Director Open Source, plusserver gmbh"
 
 - title: "Ein SCS Datacenter für das 5G-Campusnetz an der Hochschule Osnabrück"
+  title_en: "An SCS data center for the 5G campus network at Osnabrück University (DE)"
   day: 2
   start: "09:30"
   end: "09:50"
@@ -180,6 +200,7 @@
   description: "Robert Holling, Dipl.-Wirtsch.-Inf., Reallabor Hoschschule Osnabrück"
 
 - title: "Building a Community of Practice - der Betrieb von SCS-Infrastrukturen"
+  title_en: "Building a Community of Practice - Operations of SCS infrastructure (DE)"
   day: 2
   start: "09:50"
   end: "10:20"
@@ -190,6 +211,7 @@
   description: "Friederike Zelke, Community Manager SCS, OSB Alliance e.V. (Moderation); Alexander Wallner, CEO plusserver GmbH; Cemil Degirmenci, Geschäftsführer der Wavecon GmbH (100% noris network AG); Felix Kronlage-Dammers, Product Owner IaaS & OPS SCS, OSB Alliance e.V.; Christian Berendt, Founder und CEO der OSISM GmbH"
     
 - title: "Vom Oligopol zurück zum echten Wettbewerb" 
+  title_en: "From oligopoly back to real competition (DE)"
   day: 2
   start: "10:20"
   end: "10:30"
@@ -200,6 +222,7 @@
   description: "Dr. Hans-Joachim Popp, Principal Consultant@BwConsulting, Mitglied des Präsidiums, VOICE, Bundesverband der IT-Anwender"
 
 - title: "Digitale Souveränität und Gaia-X: Warum DATEV sich engagiert" 
+  title_en: "Digital Sovereignty and Gaia-X: Why does DATEV contribute? (EN)"
   day: 2
   start: "10:30"
   end: "10:40"
@@ -210,6 +233,7 @@
   description: "Jutta Rößner, Leiterin Ecosystem & EAM, Mitglied der Geschäftsleitung bei DATEV eG"
 
 - title: "Paneldiskussion"
+  title_en: "Panel discussion"
   day: 2
   start: "10:40"
   end: "11:00"
@@ -230,6 +254,7 @@
   description: ""
 
 - title: "Federation Services - Die Open Source Werkzeugkiste zum Aufbau souveräner Datenökosysteme"
+  title_en: "Federation Services - The Open Source tool box to build up sovereign data ecosystems (DE)"
   day: 2
   start: "11:30"
   end: "12:00"
@@ -240,6 +265,7 @@
   description: "Andreas Weiss, Geschäftsbereichsleiter Digitale Geschäftsmodelle, eco - Verband der Internetwirtschaft e.V."
 
 - title: "Ein Zero Emission Cloud Computing Center durch SCS betrieben"
+  title_en: "A zero emission cloud data center operated with SCS (DE)"
   day: 2
   start: "12:00"
   end: "12:15"
@@ -250,6 +276,7 @@
   description: "Julian Hauber, Geschäftsführer JH-Computers; Christian Berendt, Founder und CEO der OSISM GmbH"
 
 - title: "Was ist eigentliche eine SCS Zertifizierung"
+  title_en: "What is SCS certification? (DE)"
   day: 2
   start: "12:15"
   end: "12:25"
@@ -260,6 +287,7 @@
   description: "Alexander Diab, Ecosystem Manager SCS, OSB Alliance e.V."
 
 - title: "SCS in 5 Jahren - Ein Ausblick"
+  title_en: "SCS in 5 years - an outlook (DE)"
   day: 2
   start: "12:25"
   end: "12:55"
@@ -271,6 +299,7 @@
   slides: "https://scs.sovereignit.de/nextcloud/s/7imHjZR2NjjXLTc"
 
 - title: "Abschluss und Verabschiedung"
+  title_en: "Conclusion and Goodbye (DE)"
   day: 2
   start: "12:55"
   end: "13:00"

--- a/_data/summit2023-talks.yml
+++ b/_data/summit2023-talks.yml
@@ -97,6 +97,7 @@
   avatar:
     - "SCS_logo.png"
   description: "Johan Christenson, Vice President Innovation, Cleura AB; Kurt Garloff, CTO SCS, OSB Alliance e.V."
+  slides: "https://scs.sovereignit.de/nextcloud/s/ydXyXSmN88WL8FS"
   
 - title: "Bauen Sie Ihren eigenen Hyperscaler: Wie Sie eine souveräne Private Cloud auf Basis des Souvereign Cloud Stack aufbauen"
   day: 1
@@ -267,6 +268,7 @@
   avatar:
     - "SCS_logo.png"
   description: "Kurt Garloff, CTO SCS, OSB Alliance e.V."
+  slides: "https://scs.sovereignit.de/nextcloud/s/7imHjZR2NjjXLTc"
 
 - title: "Abschluss und Verabschiedung"
   day: 2

--- a/_i18n/de/summit2023.md
+++ b/_i18n/de/summit2023.md
@@ -62,10 +62,10 @@ Diese Seite bleibt bestehen, um die Veranstaltung zu dokumentieren und enthält 
                             aria-hidden="true"></i>{{talk.location}}</div>
                     <div class="desc pb-2">{{talk.description}}</div>
                     {% if talk.slides %}
-			<div class="desc pb-2"><a href={{talk.slides}} alt="Link zu den Folien">Folien</a></div>
+			<div class="desc pb-2"><a href="{{talk.slides}}">Folien</a></div>
 		    {% endif %}
                     {% if talk.video %}
-			<div class="desc pb-2"><a href={{talk.video}} alt="Link zum Vortragsvideo">Video</a></div>
+			<div class="desc pb-2"><a href="{{talk.video}}">Video</a></div>
 		    {% endif %}
                 </div>
                 <!--//content-->

--- a/_i18n/de/summit2023.md
+++ b/_i18n/de/summit2023.md
@@ -2,15 +2,19 @@
 
 Liebe Freunde und interessierte Beobachter von SCS,
 
-der Sovereign Cloud Stack ist erfolgreich im zweiten Jahr angekommen und hat eine aktive Community etabliert, die einen standardisierten Open Source Cloud Computing Stack entwickelt und pflegt. Erfolg heißt, dass wir die vierte Version herausgebracht haben und  drei Cloud Service Provider ihr Angebot auf SCS Standards und Technologie bereitstellen. Grund genug, um zu unserem ersten SCS Summit am **23. und 24. Mai 2023 in Berlin** einzuladen, wo Anwender, Partner und Entwickler und jeder, der mit dem Projekt verbunden ist, Wissen und Erfahrungen austauschen und - natürlich - netzwerken und Spaß haben können.
+der Sovereign Cloud Stack ist erfolgreich im zweiten Jahr angekommen und hat eine aktive Community etabliert, die einen standardisierten Open Source Cloud Computing Stack entwickelt und pflegt. Erfolg heißt, dass wir die vierte Version herausgebracht haben und ~~drei~~vier Public Cloud Service Provider ihr Angebot auf SCS Standards und Technologie bereitstellen. Grund genug, um zu unserem ersten SCS Summit am **23. und 24. Mai 2023 in Berlin** einzuladen, wo Anwender, Partner und Entwickler und jeder, der mit dem Projekt verbunden ist, Wissen und Erfahrungen austauschen und - natürlich - netzwerken und Spaß haben können.
 
-Die Registrierung am 23. Mai ist ab 12:00 Uhr möglich, die Veranstaltung beginnt um 13:00 Uhr. Am zweite Tag ist die Registrierung ab 8:00 Uhr möglich, das Programm beginnt um 9:00 und endet offiziell um 13:00 Uhr
+## Danke!
 
-## Gäste
+Die Veranstaltung ist jetzt vorbei. Wir hatten sehr interessante Vorträge und Podiumsdiskussionen auf der Bühne und wirklich gute Gespräche mit allen Teilnehmenden. Danke an alle, die teilgenommen haben, insbesondere natürlich an die Sprecherinnen und Sprecher und an die Organisatorinnen und Organisatoren.
+
+Diese Seite bleibt bestehen, um die Veranstaltung zu dokumentieren und enthält die gesammelten Links zu den Folien und den Videos.
+
+## Sprecherinnen und Sprecher
 
 {% include summit2023/speakers.html %}
 
-## Schedule
+## Zeitplan
 
 <div class="container my-4">
     <!-- Nav tabs -->
@@ -57,6 +61,12 @@ Die Registrierung am 23. Mai ist ab 12:00 Uhr möglich, die Veranstaltung beginn
                     <div class="location mb-2 text-muted"><i class="fa fa-map-marker me-2"
                             aria-hidden="true"></i>{{talk.location}}</div>
                     <div class="desc pb-2">{{talk.description}}</div>
+                    {% if talk.slides %}
+			<div class="desc pb-2"><a href={{talk.slides}} alt="Link zu den Folien">Folien</a></div>
+		    {% endif %}
+                    {% if talk.video %}
+			<div class="desc pb-2"><a href={{talk.video}} alt="Link zum Vortragsvideo">Video</a></div>
+		    {% endif %}
                 </div>
                 <!--//content-->
             </div>
@@ -69,25 +79,10 @@ Die Registrierung am 23. Mai ist ab 12:00 Uhr möglich, die Veranstaltung beginn
 
 ## Veranstaltungsort
 
-Der SCS Summit findet in den wunderschönen Räumlichkeiten der Berlin-Brandenburgischen Akademie der Wissenschaften (BBAW) statt.
+Der SCS Summit fand in den wunderschönen Räumlichkeiten der Berlin-Brandenburgischen Akademie der Wissenschaften (BBAW) statt.
 Eine [ausführliche Wegbeschreibung](https://veranstaltungszentrum.bbaw.de/en/directions) finden Sie auf der offiziellen Seite der BBAW.
 
 {% include summit2023/bbaw.html %}
-
-## Anmelden
-
-<pretix-widget event="https://events.scs.community/scs-summit-2023"></pretix-widget>
-<noscript>
-   <div class="pretix-widget">
-        <div class="pretix-widget-info-message">
-            JavaScript ist in Ihrem Browser deaktiviert. Um unseren Ticketshop ohne JavaScript aufzurufen, klicken Sie bitte <a target="_blank" rel="noopener" href="https://events.scs.community/scs-summit-2023">hier</a>.
-        </div>
-    </div>
-</noscript>
-
-## Presse
-
-Wir freuen uns darauf Presse und Medienpartner auf unserem SCS Summit zu begrüßen. Bitte melden Sie sich für eine Akkreditierung an [presse@osb-alliance.com](mailto:presse@osb-alliance.com). Gerne lassen wir Ihnen vorab eine ausführliche Pressemappe sowie die Möglichkeit auf Interviews zukommen.
 
 ## Sponsoren
 

--- a/_i18n/en/summit2023.md
+++ b/_i18n/en/summit2023.md
@@ -2,9 +2,13 @@
 
 Dear Friends of SCS and interested Observers,
 
-The Sovereign Cloud Stack is now in its second year successfully building a community to develop and maintain a standardized open source cloud computing stack. Success means that we have released the fourth version and that by now three cloud service providers base their offering on SCS standards and technology. Reason enough to call for our first summit on **23rd and 24th of May 2023 in Berlin** for users, developers, adopters and everybody, who is affiliated to this project to gather, share knowledge, as well as experience and to – of course – network and have fun.
+The Sovereign Cloud Stack is now in its second year successfully building a community to develop and maintain a standardized open source cloud computing stack. Success means that we have released the fourth version and that by now ~~three~~ four public cloud service providers base their offering on SCS standards and technology. Reason enough to call for our first summit, which happened on **23rd and 24th of May 2023 in Berlin** for users, developers, adopters and everybody, who is affiliated to this project to gather, share knowledge, as well as experience and to – of course – network and have fun.
 
-Registration on 23 May is possible from 12:00 CEST, the event will start at 13:00 CEST. The second day starts with registration at 8:00 CEST, program begins at 9:00 CEST and officially ends at 13:00 CEST.
+## Thank you!
+
+The event is now over. We had really interesting presentations and panel discussions on stage and really good conversations with all participants. Thanks for everyone who joined us, but especially the speakers and organizers!
+
+This page will remain in place, documenting the event and containing links to the slides and videos from the program.
 
 ## Speakers
 
@@ -57,7 +61,13 @@ Registration on 23 May is possible from 12:00 CEST, the event will start at 13:0
                     <div class="location mb-2 text-muted"><i class="fa fa-map-marker me-2"
                             aria-hidden="true"></i>{{talk.location}}</div>
                     <div class="desc pb-2">{{talk.description}}</div>
-                </div>
+                    {% if talk.slides %}
+			<div class="desc pb-2"><a href={{talk.slides}}>Slides</a></div>
+		    {% endif %}
+                    {% if talk.video %}
+			<div class="desc pb-2"><a href={{talk.video}}>Video</a></div>
+		    {% endif %}
+		</div>
                 <!--//content-->
             </div>
             {% endif %}
@@ -69,24 +79,9 @@ Registration on 23 May is possible from 12:00 CEST, the event will start at 13:0
 
 ## Location
 
-The SCS Summit will take place in the beautiful facilities of the Berlin-Brandenburg Academy of Sciences and Humanities (BBAW). You can find [detailed directions on the official BBAW website](https://veranstaltungszentrum.bbaw.de/en/directions).
+The SCS Summit took place in the beautiful facilities of the Berlin-Brandenburg Academy of Sciences and Humanities (BBAW). You can find [detailed directions on the official BBAW website](https://veranstaltungszentrum.bbaw.de/en/directions).
 
 {% include summit2023/bbaw.html %}
-
-## Register
-
-<pretix-widget event="https://events.scs.community/scs-summit-2023"></pretix-widget>
-<noscript>
-   <div class="pretix-widget">
-        <div class="pretix-widget-info-message">
-            JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://events.scs.community/scs-summit-2023">click here</a>.
-        </div>
-    </div>
-</noscript>
-
-## Press
-
-We look forward to welcoming press and media partners to our SCS Summit. For accreditation, please contact [presse@osb-alliance.com](mailto:presse@osb-alliance.com). We will be happy to send you a detailed press kit and the opportunity for interviews in advance.
 
 ## Sponsors
 

--- a/_i18n/en/summit2023.md
+++ b/_i18n/en/summit2023.md
@@ -62,10 +62,10 @@ This page will remain in place, documenting the event and containing links to th
                             aria-hidden="true"></i>{{talk.location}}</div>
                     <div class="desc pb-2">{{talk.description}}</div>
                     {% if talk.slides %}
-			<div class="desc pb-2"><a href={{talk.slides}}>Slides</a></div>
+			<div class="desc pb-2"><a href="{{talk.slides}}">Slides</a></div>
 		    {% endif %}
                     {% if talk.video %}
-			<div class="desc pb-2"><a href={{talk.video}}>Video</a></div>
+			<div class="desc pb-2"><a href="{{talk.video}}">Video</a></div>
 		    {% endif %}
 		</div>
                 <!--//content-->

--- a/_i18n/en/summit2023.md
+++ b/_i18n/en/summit2023.md
@@ -56,14 +56,13 @@ This page will remain in place, documenting the event and containing links to th
                 <div class="content">
 		    {% if talk.title_en %}
                     <h3 class="title mb-2">{{talk.title_en}}<a data-tab-destination="day-{{i}}"
-                            href="#session-{{ forloop.index }}" class="link-unstyled"><i
-                                class="fa fa-link ms-2 text-muted" aria-hidden="true" style="font-size: .7em;"></i></a>
+                            href="#session-{{ forloop.index }}" class="link-unstyled">
 		    {% else %}
                     <h3 class="title mb-2">{{talk.title}}<a data-tab-destination="day-{{i}}"
-                            href="#session-{{ forloop.index }}" class="link-unstyled"><i
-                                class="fa fa-link ms-2 text-muted" aria-hidden="true" style="font-size: .7em;"></i></a>
-                    </h3>
+                            href="#session-{{ forloop.index }}" class="link-unstyled">
                     {% endif %}
+			<i class="fa fa-link ms-2 text-muted" aria-hidden="true" style="font-size: .7em;"></i></a>
+                    </h3>
                     <div class="location mb-2 text-muted"><i class="fa fa-map-marker me-2"
                             aria-hidden="true"></i>{{talk.location}}</div>
                     {% if talk.description_en %}

--- a/_i18n/en/summit2023.md
+++ b/_i18n/en/summit2023.md
@@ -54,13 +54,23 @@ This page will remain in place, documenting the event and containing links to th
                 </div>
                 <!--//meta-->
                 <div class="content">
+		    {% if talk.title_en %}
+                    <h3 class="title mb-2">{{talk.title_en}}<a data-tab-destination="day-{{i}}"
+                            href="#session-{{ forloop.index }}" class="link-unstyled"><i
+                                class="fa fa-link ms-2 text-muted" aria-hidden="true" style="font-size: .7em;"></i></a>
+		    {% else %}
                     <h3 class="title mb-2">{{talk.title}}<a data-tab-destination="day-{{i}}"
                             href="#session-{{ forloop.index }}" class="link-unstyled"><i
                                 class="fa fa-link ms-2 text-muted" aria-hidden="true" style="font-size: .7em;"></i></a>
                     </h3>
+                    {% endif %}
                     <div class="location mb-2 text-muted"><i class="fa fa-map-marker me-2"
                             aria-hidden="true"></i>{{talk.location}}</div>
+                    {% if talk.description_en %}
+                    <div class="desc pb-2">{{talk.description_en}}</div>
+		    {% else %}
                     <div class="desc pb-2">{{talk.description}}</div>
+                    {% endif %}
                     {% if talk.slides %}
 			<div class="desc pb-2"><a href="{{talk.slides}}">Slides</a></div>
 		    {% endif %}


### PR DESCRIPTION
Change the wording on the summit page slightly to indicate we know it's over.
State that we keep the page around to document the event and have slides and videos collected here.
Link to slides and videos can just be added to the yaml talks data file (_data/summit2023-talks.yml) and should then just appear.
Note: The staging page does not load the .css ... assets and does not allow to test this completely.