### PR TITLE
Add vocabulary to list to fix build.

### DIFF
--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -88,6 +88,7 @@ tenders:
     lot9c: "Penetration Testing"
     lot10: "SCS Zertifizierung"
     lot11: "Aufbau Serverhardware"
+    lot12: "Cloud/Container Plaftform health monitoring"
     lot13: "Nutzungsmessung auf IaaS-Ebene"
     lot18: "Beschaffung Rechenzentrums-Hardware und Betrieb"
   filter:

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -89,6 +89,7 @@ tenders:
     lot9c: "Penetration Testing"
     lot10: "SCS certification"
     lot11: "Server Hardware Installation"
+    lot12: "Cloud/Container platform health monitoring"
     lot13: "Metering on IaaS layer"
     lot18: "Procurement of Data Centre Hardware and Operation"
   filter:

--- a/_tenders/lot12.md
+++ b/_tenders/lot12.md
@@ -2,7 +2,7 @@
 title_slug: tenders.title.lot12
 layout: default
 
-number: 17
+number: 16
 number_vh81: 12
 retry: 1
 start_date: 2023-07-19

--- a/_tenders/lot13.md
+++ b/_tenders/lot13.md
@@ -2,7 +2,7 @@
 title_slug: tenders.title.lot13
 layout: default
 
-number: 18
+number: 17
 number_vh81: 13
 start_date: 2022-08-18
 closing_date: 2022-09-12


### PR DESCRIPTION
Also do some renumbering. Keep 18->VP18, 17->VP13 and 16->VP12. There seems to be no VP11 (as this has become part of 18), so 16 is unused.