### PR TITLE
Rename federation blog post to reflect publication date Oct 19.

### DIFF
--- a/_i18n/de/_posts/blog/2023-09-05-progress-openstack-cli-with-federation.md
+++ b/_i18n/de/_posts/blog/2023-09-05-progress-openstack-cli-with-federation.md
@@ -1,1 +1,0 @@
-../../../en/_posts/blog/2023-09-05-progress-openstack-cli-with-federation.md

--- a/_i18n/de/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md
+++ b/_i18n/de/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md
@@ -1,0 +1,1 @@
+../../../en/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md

--- a/_i18n/en/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md
+++ b/_i18n/en/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md
@@ -52,3 +52,8 @@ explained that they found an even better solution.
 This has been [merged into the testbed](https://github.com/osism/testbed/pull/1717) some weeks ago
 and we will continue with making that fix part of the bigger move to ship our configuration for identity federation
 as part of the OSISM Cookiecutter repository to make it easily available to productive deployments of SCS.
+
+<font size="small">
+Editorial note/Changelog 2023-10-27: While most of this was written before Sep 5 and thus originally had a
+planned publication date of Sep 5, it was only ultimately approved and published on Oct 19. We have now changed
+the publication date to reflect that and no longer claim Sep 5.</font>

--- a/_i18n/en/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md
+++ b/_i18n/en/_posts/blog/2023-10-19-progress-openstack-cli-with-federation.md
@@ -53,7 +53,7 @@ This has been [merged into the testbed](https://github.com/osism/testbed/pull/17
 and we will continue with making that fix part of the bigger move to ship our configuration for identity federation
 as part of the OSISM Cookiecutter repository to make it easily available to productive deployments of SCS.
 
-<font size="small">
+<p style="font-size:12px; ">
 Editorial note/Changelog 2023-10-27: While most of this was written before Sep 5 and thus originally had a
 planned publication date of Sep 5, it was only ultimately approved and published on Oct 19. We have now changed
-the publication date to reflect that and no longer claim Sep 5.</font>
+the publication date to reflect that and no longer claim Sep 5.</p>


### PR DESCRIPTION
This should address #764. It is clean, because the federation blog article indeed only went live on Oct 19.
Nevertheless, I have added a note at the bottom of the article to make this transparent.
I pushed this to the staging branch, so we can see the live result (in 10 mins or so) before approving and merging this.