### PR TITLE
Feat/add events page

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -15,6 +15,9 @@
 - title: nav.news
   link: /news/
 
+- title: nav.events
+  link: /events/
+
 - title: nav.jobs
   link: /jobs/
 

--- a/_data/tiles.yml
+++ b/_data/tiles.yml
@@ -3,6 +3,11 @@
   action: tiles.news.action
   link: /news/
   color: "mint"
+- title: tiles.events.title
+  body: tiles.events.body
+  action: tiles.events.action
+  link: /events/
+  color: "mint"
 - title: tiles.documentation.title
   body: tiles.documentation.body
   action: tiles.documentation.action

--- a/_data/tiles.yml
+++ b/_data/tiles.yml
@@ -3,11 +3,6 @@
   action: tiles.news.action
   link: /news/
   color: "mint"
-- title: tiles.events.title
-  body: tiles.events.body
-  action: tiles.events.action
-  link: /events/
-  color: "mint"
 - title: tiles.documentation.title
   body: tiles.documentation.body
   action: tiles.documentation.action

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -58,6 +58,7 @@ tiles:
     action: "Details"
 events:
   title: "Veranstaltungen"
+  hint: "Weiteres gibt es auf unserer Veranstaltungsseite."
 news:
   announcements: "Eigene Ankündigungen"
   blog: "Community-Blog"

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -16,6 +16,7 @@ nav:
   jobs: "Offene Stellen"
   tenders: "Ausschreibungen"
   docs: "Dokumentation"
+  events: "Veranstaltungen"
   contribute: "Zu SCS beitragen"
   summit2023: "Unser erster SCS Summit findet am 23. and 24. Mai 2023 in Berlin statt."
 footer:
@@ -51,6 +52,10 @@ tiles:
     title: "Ausschreibungen"
     body: "Wichtige Bausteine sollen über offene Ausschreibungen an Unternehmen vergeben werden, welche hier regelmäßig veröffentlich werden."
     action: "Bewerben &raquo;"
+  events:
+    title: "Veranstaltungen"
+    body: "Veranstaltungen, die durch das SCS Team (mit)organisiert werden sowie die wichtigsten Veranstaltungen, an denen SCS aktiv teilnimmt."
+    action: "Details"
 news:
   announcements: "Eigene Ankündigungen"
   blog: "Community-Blog"

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -56,6 +56,8 @@ tiles:
     title: "Veranstaltungen"
     body: "Veranstaltungen, die durch das SCS Team (mit)organisiert werden sowie die wichtigsten Veranstaltungen, an denen SCS aktiv teilnimmt."
     action: "Details"
+events:
+  title: "Veranstaltungen"
 news:
   announcements: "Eigene Ankündigungen"
   blog: "Community-Blog"

--- a/_i18n/de.yml
+++ b/_i18n/de.yml
@@ -58,7 +58,6 @@ tiles:
     action: "Details"
 events:
   title: "Veranstaltungen"
-  hint: "Weiteres gibt es auf unserer Veranstaltungsseite."
 news:
   announcements: "Eigene Ankündigungen"
   blog: "Community-Blog"
@@ -72,6 +71,7 @@ news:
     title: "Konferenzbeiträge"
     slides: "Folien"
   read_more: "Weiterlesen..."
+  events_link: "Mehr auf unserer Veranstaltungsseite."
 tenders:
   name: "Name"
   description: "Beschreibung"

--- a/_i18n/de/events.md
+++ b/_i18n/de/events.md
@@ -4,10 +4,10 @@
 
 ### SCS Summits
 
-Der [SCS Summit 2023](summit2023) war ein großer Erfolg, und daher planen wir für den 14.5.2024
-unseren [SCS Summit 2024](summit2024) in Berlin. Die Veranstaltung wird wieder primär deutschsprachig
+Der [SCS Summit 2023](/summit2023) war ein großer Erfolg, und daher planen wir für den 14.5.2024
+unseren [SCS Summit 2024](/summit2024) in Berlin. Die Veranstaltung wird wieder primär deutschsprachig
 sein mit Entscheidungsträgern aus Politik und Wirtschaft als primärer Zielgruppe. Am Folgetag
-findet am selben Ort ein [Open Infra Day](stack.org/events/openstackdays#tab=events_tab) statt,
+findet am selben Ort ein [Open Infra Day](https://openstack.org/events/openstackdays#tab=events_tab) statt,
 mit primär englischsprachigen Inhalten und sehr viel technischerer Ausrichtung.
 
 ### SCS Hackathons
@@ -15,7 +15,7 @@ mit primär englischsprachigen Inhalten und sehr viel technischerer Ausrichtung.
 Nach den erfolgreichen Hackathons in Köln (22.11.2022 bei [PlusServer](https://plusserver.com/))
 und in Nürnberg (2.3.2023 bei [Noris/Wavecon](https://wavecon.de/)) und einigen 
 Workshops/Mini-Hackathons findet der dritte große Hackathon in Kooperation mit
-[Alasca e.V.](https://alsaca.cloud/)) am 8.11. bei [Cloud & Heat](https://cloudandheat.com/)
+[Alasca e.V.](https://alasca.cloud/)) am 8.11. bei [Cloud & Heat](https://cloudandheat.com/)
 in Dresden statt. Eine [Anmeldung](https://events.scs.community/hackathon-3/) ist erforderlich,
 weil die Raumkapazitäten begrenzt sind.
 

--- a/_i18n/de/events.md
+++ b/_i18n/de/events.md
@@ -1,6 +1,6 @@
 # Veranstaltungen
 
-## Eigene Veranstaltungen: SCS Hackathons und SCS Summits
+## Eigene Veranstaltungen
 
 ### SCS Summits
 

--- a/_i18n/de/events.md
+++ b/_i18n/de/events.md
@@ -1,0 +1,22 @@
+# Veranstaltungen
+
+## Eigene Veranstaltungen: SCS Hackathons und SCS Summits
+
+### SCS Summits
+
+Der [SCS Summit 2023](summit2023) war ein großer Erfolg, und daher planen wir für den 14.5.2024
+unseren [SCS Summit 2024](summit2024) in Berlin. Die Veranstaltung wird wieder primär deutschsprachig
+sein mit Entscheidungsträgern aus Politik und Wirtschaft als primärer Zielgruppe. Am Folgetag
+findet am selben Ort ein [Open Infra Day](stack.org/events/openstackdays#tab=events_tab) statt,
+mit primär englischsprachigen Inhalten und sehr viel technischerer Ausrichtung.
+
+### SCS Hackathons
+
+Nach den erfolgreichen Hackathons in Köln (22.11.2022 bei [PlusServer](https://plusserver.com/))
+und in Nürnberg (2.3.2023 bei [Noris/Wavecon](https://wavecon.de/)) und einigen 
+Workshops/Mini-Hackathons findet der dritte große Hackathon in Kooperation mit
+[Alasca e.V.](https://alsaca.cloud/)) am 8.11. bei [Cloud & Heat](https://cloudandheat.com/)
+in Dresden statt. Eine [Anmeldung](https://events.scs.community/hackathon-3/) ist erforderlich,
+weil die Raumkapazitäten begrenzt sind.
+
+<!--TODO: ## Veranstaltungen mit aktiver SCS Teilnahme-->

--- a/_i18n/de/summit2024.md
+++ b/_i18n/de/summit2024.md
@@ -10,10 +10,6 @@ Merken Sie sich diesen Termin vor. Wir freuen uns auf Ihre Teilnahme! Lassen Sie
 
 Wir freuen uns besonders, dass unser Summit mit dem Auftakt der OpenInfra Day Roadshow kombiniert wird. Der [OpenInfra Day Germany 2024](https://superuser.openinfra.dev/articles/openinfra-event-strategy-update/) findet am Mittwoch, den 15. Mai 2024 in den gleichen Räumlichkeiten wie unser Summit statt. Nutzen Sie die einmalige Gelegenheit, am ersten Tag SCS, unsere Partner und unsere Community kennenzulernen, und am zweiten Tag in die Welt der Open-Source-Community-Arbeit einzutauchen. Wir laden Sie herzlich dazu ein.
 
-Wir danken Ihnen,
-
-Das Team des Sovereign Cloud Stack Summit
-
 [Hier](https://scs.community/summit2023) finden Sie die Präsentationen und Vorträge des Summit 2023.
 
 ## Kontakt

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -56,6 +56,8 @@ tiles:
     title: "Events"
     body: "Events that are (co)organized by the SCS Team as well as important events with contributions from SCS."
     action: "More details"
+events:
+  title: "Events"
 news:
   announcements: "Own Announcements"
   blog: "Community Blog"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -16,6 +16,7 @@ nav:
   jobs: "Open positions"
   tenders: "Public tenders"
   docs: "Documentation"
+  events: "Events"
   contribute: "Contribute to SCS"
   summit2023: "Join us for our first SCS Summit on 23rd and 24th of May 2023 in Berlin."
 footer:
@@ -51,6 +52,10 @@ tiles:
     title: "Tenders"
     body: "Important building blocks will be awarded to companies through open tenders, which will be continously published on this page."
     action: "Apply &raquo;"
+  events:
+    title: "Events"
+    body: "Events that are (co)organized by the SCS Team as well as important events with contributions from SCS."
+    action: "More details"
 news:
   announcements: "Own Announcements"
   blog: "Community Blog"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -72,7 +72,7 @@ news:
     title: "Conference Contributions"
     slides: "Slides"
   read_more: "Read more..."
-  event_link: "See also our events page."
+  events_link: "See also our events page."
 tenders:
   name: "Name"
   description: "Description"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -58,7 +58,6 @@ tiles:
     action: "More details"
 events:
   title: "Events"
-  hint: "Please also see our Events page"
 news:
   announcements: "Own Announcements"
   blog: "Community Blog"
@@ -73,6 +72,7 @@ news:
     title: "Conference Contributions"
     slides: "Slides"
   read_more: "Read more..."
+  event_link: "See also our events page."
 tenders:
   name: "Name"
   description: "Description"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -58,6 +58,7 @@ tiles:
     action: "More details"
 events:
   title: "Events"
+  hint: "Please also see our Events page"
 news:
   announcements: "Own Announcements"
   blog: "Community Blog"

--- a/_i18n/en/events.md
+++ b/_i18n/en/events.md
@@ -4,12 +4,12 @@
 
 ### SCS Summits
 
-The [2023 SCS Summit](summit2023) was a big success, so we are planning the
-[2024 SCS Summit](summit2024) now for May 14, 2024 in Berlin.
+The [2023 SCS Summit](/summit2023) was a big success, so we are planning the
+[2024 SCS Summit](/summit2024) now for May 14, 2024 in Berlin.
 The event will be primarily focused on policy makers and decision takers
 in the industry again and will be primarily held in German language.
 The next day, in the same location, we are co-organizing the
-[Open Infra Day](stack.org/events/openstackdays#tab=events_tab),
+[Open Infra Day](https://openstack.org/events/openstackdays#tab=events_tab),
 a much more technical event, with primarily English lanuage content.
 
 ### SCS Hackathons
@@ -17,7 +17,7 @@ a much more technical event, with primarily English lanuage content.
 Afer successful Hackathons in Cologne (Nov 22, 2022 at [PlusServer](https://plusserver.com/))
 and in Nuremberg (Mar 2, 2023 at [Noris/Wavecon](https://wavecon.de/)) and a number of
 Workshops/Mini-Hackathons, the third full-size Hackathon is orgainzed in collaboration with
-[Alasca e.V.](https://alsaca.cloud/)) on Nov 8, 2023 at [Cloud & Heat](https://cloudandheat.com/)
+[Alasca e.V.](https://alasca.cloud/)) on Nov 8, 2023 at [Cloud & Heat](https://cloudandheat.com/)
 premises in Dresden. [Registration](https://events.scs.community/hackathon-3/) is compulsory
 as room capacity is limited.
 

--- a/_i18n/en/events.md
+++ b/_i18n/en/events.md
@@ -1,6 +1,6 @@
 # Events
 
-## Own events: SCS Hackathons und SCS Summits
+## Own events
 
 ### SCS Summits
 

--- a/_i18n/en/events.md
+++ b/_i18n/en/events.md
@@ -1,0 +1,24 @@
+# Events
+
+## Own events: SCS Hackathons und SCS Summits
+
+### SCS Summits
+
+The [2023 SCS Summit](summit2023) was a big success, so we are planning the
+[2024 SCS Summit](summit2024) now for May 14, 2024 in Berlin.
+The event will be primarily focused on policy makers and decision takers
+in the industry again and will be primarily held in German language.
+The next day, in the same location, we are co-organizing the
+[Open Infra Day](stack.org/events/openstackdays#tab=events_tab),
+a much more technical event, with primarily English lanuage content.
+
+### SCS Hackathons
+
+Afer successful Hackathons in Cologne (Nov 22, 2022 at [PlusServer](https://plusserver.com/))
+and in Nuremberg (Mar 2, 2023 at [Noris/Wavecon](https://wavecon.de/)) and a number of
+Workshops/Mini-Hackathons, the third full-size Hackathon is orgainzed in collaboration with
+[Alasca e.V.](https://alsaca.cloud/)) on Nov 8, 2023 at [Cloud & Heat](https://cloudandheat.com/)
+premises in Dresden. [Registration](https://events.scs.community/hackathon-3/) is compulsory
+as room capacity is limited.
+
+<!--TODO: ## Events with contributions from SCS-->

--- a/_i18n/en/summit2024.md
+++ b/_i18n/en/summit2024.md
@@ -10,10 +10,6 @@ Save the date, as we look forward to your participation in the Sovereign Cloud S
 
 We are particularly pleased that our Summit will be combined with the kick-off of the OpenInfra Day Roadshow. [OpenInfra Day Germany 2024](https://superuser.openinfra.dev/articles/openinfra-event-strategy-update/) will take place on May 15, 2024 at the same venue as our Summit. Take advantage of this unique opportunity to meet SCS, our partners and our community on the first day, and dive into the world of open source community work on the second day. We cordially invite you to join us.
 
-We thank you,
-
-The Sovereign Cloud Stack Summit Team
-
 [Here](https://scs.community/summit2023) you can find the presentations and talks of Summit 2023.
 
 ## Contact us

--- a/_includes/news/link_events.html
+++ b/_includes/news/link_events.html
@@ -1,0 +1,3 @@
+<div class="d-grid">
+  <a href="{{ site.baseurl }}/{{ include.ref }}/" class="btn btn-outline-primary" role="button">{% t news.events_link %}</a>
+</div>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -17,4 +17,5 @@ layout: default
 	{% include news/conferences.html limit="3" title_slug="news.conference.en" icon="fa-comment-o" data=site.data.conferences_en %}
 	{% include news/conferences.html limit="3" title_slug="news.conference.de" icon="fa-comment-o" data=site.data.conferences_de %}
 	{% include news/read_more.html ref="conferences" %}
+	<a href="/events">{% events.hint %}</a>
 </div>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -17,5 +17,5 @@ layout: default
 	{% include news/conferences.html limit="3" title_slug="news.conference.en" icon="fa-comment-o" data=site.data.conferences_en %}
 	{% include news/conferences.html limit="3" title_slug="news.conference.de" icon="fa-comment-o" data=site.data.conferences_de %}
 	{% include news/read_more.html ref="conferences" %}
-	<a href="/events">{% events.hint %}</a>
+	{% include news/link_events.html ref="/events" %}
 </div>

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -1,4 +1,3 @@
-
 ---
 title_slug: events.title
 layout: default

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -1,0 +1,10 @@
+
+---
+title_slug: events.title
+layout: default
+permalink: /events/
+---
+<div class="row">
+	{% include events.html title_slug="events.en" icon="fa-comment-o" data=site.data.events_en %}
+	{% include events.html title_slug="events.de" icon="fa-comment-o" data=site.data.events_de %}
+</div>

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -2,8 +2,7 @@
 title_slug: events.title
 layout: default
 permalink: /events/
+redirect_from:
+   - /Events/
 ---
-<div class="row">
-	{% include events.html title_slug="events.en" icon="fa-comment-o" data=site.data.events_en %}
-	{% include events.html title_slug="events.de" icon="fa-comment-o" data=site.data.events_de %}
-</div>
+{% tf events.md %}

--- a/_pages/summit2024/summit2024.md
+++ b/_pages/summit2024/summit2024.md
@@ -1,8 +1,10 @@
 ---
 title: Sovereign Cloud Stack Summit 2024
 layout: default
-permalink: /summit/
+permalink: /summit2024/
 image: summit2024/banner.png
+redirect_from:
+   - /summit/
 ---
 
 {% include_relative summit2024-content.md %}


### PR DESCRIPTION
This PR does a few things:
* There is a new Events page
  - It's linked from the Top Menu bar
  - It also has a link from the News page
  - I dropped the tile from the home page, as 5 tiles don't look nice
* The page currently has our two summits and the hackathons listed, not yet events where we contribute/participate.

You can check how this looks by looking at https://staging.scs.community/

Behind the scenes: summit has been renamed to summit2024, but summit is linking to summit2023 currently.

Not yet done: Remove IPCEI-CIS box on home page and replace it with a nice text pointing to our summit.