### PR TITLE
fix(blog): cluster stacks - replace curly quotation marks

### DIFF
--- a/_i18n/de/_posts/blog/2023-12-23-clusterstacks.md
+++ b/_i18n/de/_posts/blog/2023-12-23-clusterstacks.md
@@ -2,10 +2,10 @@
 layout: post
 title: "Cluster Stacks"
 author:
-  - “Janis Kemper”
-  - “Sven Batista Steinbach”
-  - “Jan Schoone”
-  - “Alexander Diab”
+  - "Janis Kemper"
+  - "Sven Batista Steinbach"
+  - "Jan Schoone"
+  - "Alexander Diab"
 avatar:
   - "jkemper.jpeg"
   - "avatar-syself.jpeg"


### PR DESCRIPTION
Replaces the curly quotation marks with ASCII quotation marks, so that the YAML conversion removes them on the website