### PR TITLE
fix: use correct avatar for Marius Feldmann

### DIFF
--- a/_members/feldmann.md
+++ b/_members/feldmann.md
@@ -9,7 +9,7 @@ firstname: Marius
 role: Chief Operating Officer 
 company: Cloud&Heat Technologies
 companylink: https://www.cloudandheat.com/
-avatar: Marius_Feldmann-200x200.webp
+avatar: mfeldmann.jpg
 bio: |
   Marius Feldmann is COO of Cloud&Heat Technologies and in this role is responsible for the technological development of the Cloud&Heat software stack, for the operation of the cloud infrastructure and for strategic business development and market orientation. In this context, he has anchored Cloud&Heat Technologies in several strategically important partnerships and initiatives. Particularly noteworthy are the initiation of Yaook, an open-source cloud lifecycle management system, together with Schwarz IT, his involvement in Gaia-X since the start of the initiative and his role as a board member of ALASCA - the Association for Operable, Open Cloud Infrastructures.
 ---


### PR DESCRIPTION
The correct avatar is already present: https://github.com/SovereignCloudStack/website/blob/main/_assets/images/mfeldmann.jpg
Just use it.