### PR TITLE
Update Mastodon links

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,6 +1,6 @@
 - title: Mastodon
   icon: fa-mastodon fa-lg
-  link: https://fosstodon.org/@sovereigncloudstack
+  link: https://social.osb-alliance.de/@SCS
 - title: LinkedIn
   icon: fa-linkedin-square fa-lg
   link: https://www.linkedin.com/company/sovereigncloudstack

--- a/_i18n/en/_posts/blog/2022-11-15-hackathon-preparation.md
+++ b/_i18n/en/_posts/blog/2022-11-15-hackathon-preparation.md
@@ -60,7 +60,7 @@ We thank [plusserver](https://www.plusserver.com/), who will provide us with eno
 
 ## Social Media
 
-Please help us to spread the word about this great event and make the public aware of the awesome momentum within our community. You can use the above banner for your social media accounts or posts to raise awareness about  your participation among your audience. Don't forget to tag your posts with #SCSCH2022 and leave a mention for [@Sovereign Cloud Stack](https://www.linkedin.com/showcase/sovereigncloudstack), [@sovereigncloudstack@fosstodon.org](https://fosstodon.org/@sovereigncloudstack), and/or [@scs_osballiance](https://twitter.com/scs_osballiance). Thank you!
+Please help us to spread the word about this great event and make the public aware of the awesome momentum within our community. You can use the above banner for your social media accounts or posts to raise awareness about  your participation among your audience. Don't forget to tag your posts with #SCSCH2022 and leave a mention for [@Sovereign Cloud Stack](https://www.linkedin.com/showcase/sovereigncloudstack), [@SCS@social.osb-alliance.de](https://social.osb-alliance.de/@SCS), and/or [@scs_osballiance](https://twitter.com/scs_osballiance). Thank you!
 
 
 Don't hesitate to reach out if you should have any other questions or feedback. We are already looking forward to welcoming you next week!


### PR DESCRIPTION
When following the Mastodon link in the page header of https://scs.community/, one is advised to also follow the moved account.

This replaces the depreciated https://fosstodon.org/@sovereigncloudstack link with the updated https://social.osb-alliance.de/@SCS