### PR TITLE
Use direct link to cloud report digisov article.

### DIFF
--- a/_data/news_en.yml
+++ b/_data/news_en.yml
@@ -14,7 +14,7 @@
   publisher: "the cloud report"
   title: "1/2022: Why digital sovereignty is more than mere legal compliance"
   details: "Eduard Itrich, Kurt Garloff, Felix Kronlage-Dammers"
-  link: "https://the-report.cloud/downloads"
+  link: "https://the-report.cloud/why-digital-sovereignty-is-more-than-mere-legal-compliance/"
 
 - date: "2021-09-09"
   publisher: "the cloud report"


### PR DESCRIPTION
The previous link was hiding the article behind a registration barrier. This was maybe nice to cloudical, but we can provide a direct link, which is nicer for the users/readers.