### PR TITLE
CTO 2021-2024. Change email and phone to persistent ones.

### DIFF
--- a/_employees/garloff.md
+++ b/_employees/garloff.md
@@ -4,15 +4,15 @@ layout: employee
 
 lastname: Garloff
 firstname: Kurt
-role: CTO Sovereign Cloud Stack
+role: CTO Sovereign Cloud Stack (2021-2024)
 company: Open Source Business Alliance - Bundesverband für digitale Souveränität e.V.
 companylink: https://osb-alliance.com
 avatar: employees/Garloff.jpg
 linkedin: https://www.linkedin.com/in/kurt-garloff/
 github: https://github.com/garloff
 matrix: https://matrix.to/#/@garloff:matrix.org
-mail: garloff@osb-alliance.com
-phone: +49-30-206539-201
+mail: scs@garloff.de
+phone: +49-221-292772-92
 street: Pariser Platz 6a
 city: Berlin
 state: Berlin


### PR DESCRIPTION
I will not be reachable via the phone no given here after 2024. I don't know yet whether or not the same is true for the mail address. So publish working contact information.
And indicate that the employment as CTO SCS is only until 2024.