### PR TITLE
Pin google-protobuf to 3.25.5 for now.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,10 +70,10 @@ GEM
     ffi (1.17.0)
     ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
-    google-protobuf (4.28.2)
+    google-protobuf (3.25.5)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.2-x86_64-linux)
+    google-protobuf (3.25.5-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -158,10 +158,10 @@ GEM
       logger
     safe_yaml (1.0.5)
     sass-embedded (1.78.0)
-      google-protobuf (~> 4.27)
+      google-protobuf (~> 3.25.5, < 3.25.6)
       rake (>= 13)
     sass-embedded (1.78.0-x86_64-linux-gnu)
-      google-protobuf (~> 4.27)
+      google-protobuf (~> 3.25.5, < 3.25.6)
     sassc (2.4.0)
       ffi (~> 1.9)
     securerandom (0.4.1)


### PR DESCRIPTION
3.25.6 has broken the build with a segfault(!).

This is the temporary solution for issue #1090.