### PR TITLE
Feat/conf links visible

### DIFF
--- a/_data/conferences_de.yml
+++ b/_data/conferences_de.yml
@@ -104,7 +104,7 @@
   event: "FOSSGIS-Konferenz 2024, HH"
   title: "Sovereign Cloud Stack: Offene, föderierbare Cloud-Technologie für jeden Sektor"
   link: "https://pretalx.com/fossgis2024/talk/FHTKUF/"
-  #link: "https://files.fossgis.de/Konferenz/2024/fossgis_tagungsband_2024_digital.pdf"
+  links: "https://files.fossgis.de/Konferenz/2024/fossgis_tagungsband_2024_digital.pdf"
   slides: "Folien_FOSSGIS-20240320_Urban_Manuela.pdf"
   details: "Dr. Manuela Urban"
 

--- a/_data/conferences_en.yml
+++ b/_data/conferences_en.yml
@@ -85,8 +85,8 @@
   event: "C4DT Conference on Trustworthy and Sovereign Cloud Computing, Lausanne"
   title: "Sovereign Cloud Stack: Open Source and Open Operations Solutions"
   details: "Dr. Manuela Urban"
-  link: "https://drive.switch.ch/index.php/s/0oEA3iWCn5VoBOA?path=%2FPart%202%3A%20Exploring%20latest%20technical%20solutions#/files_mediaviewer/06_manuela_urban%20(1080p).mp4"
-  #link: "https://drive.switch.ch/index.php/s/0oEA3iWCn5VoBOA/download?path=%2FPart%202%3A%20Exploring%20latest%20technical%20solutions&files=06_manuela_urban%20(1080p).mp4"
+  links: "https://drive.switch.ch/index.php/s/0oEA3iWCn5VoBOA?path=%2FPart%202%3A%20Exploring%20latest%20technical%20solutions#/files_mediaviewer/06_manuela_urban%20(1080p).mp4"
+  link: "https://drive.switch.ch/index.php/s/0oEA3iWCn5VoBOA/download?path=%2FPart%202%3A%20Exploring%20latest%20technical%20solutions&files=06_manuela_urban%20(1080p).mp4"
   slides: "EPFL-20230913-Urban_Manuela.pdf"
 
 - date: "2023-09-13"

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -9,7 +9,7 @@
         <h5 style="font-size:.875em">{{item.event}}</h5>
 	{% if item.link %}
           <a href="{{item.link}}" target="_blank" class="mb-1 text-decoration-none text-body stretched-link">
-	   <small><i class="fa fa-square-caret-right my-auto"></i></small> {{item.title}}</a>
+	   <small><i class="fa caret-square-o-right my-auto"></i></small> {{item.title}}</a>
 	{% else %}
 	{{item.title}}
 	{% endif %}

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -15,17 +15,19 @@
 	{% endif %}
         {% if item.details %}<p class="mb-1 small fw-light">— {{item.details}}</p>{% endif %}
       </div>
-      <div class="d-flex w-25 flex-column justify-content-start text-end position-relative">
+      <div class="d-flex w-20 flex-column justify-content-start text-end position-relative">
         <small>{% include date.html date=item.date %}</small>
         {% if item.slides %}
           <a class="mt-1 text-decoration-none text-secondary stretched-link" href="{% asset '{{item.slides}}' @path %}" target="_blank">
             <i class="fa fa-download my-auto"></i> <small>{% t news.conference.slides %}</small>
-	  </a><br/>
+	  </a>
         {% endif %}
 	{% if item.links %}
 	 {% for link in item.links %}
-	  <a class="mt-1 text-decoration-none text-secondary stretched-link" href="{link}" target="_blank">
-	   <i class="fa fa-link my-auto"></i> </a>
+          <div class="d-flex w-5 flex-column justify-content-start text-end position-relative">
+	   <a class="mt-1 text-decoration-none text-secondary stretched-link" href="{{link}}" target="_blank">
+	    <i class="fa fa-link my-auto"></i></a>
+	  </div>
 	 {% endfor %}
 	{% endif %}
       </div>

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -20,8 +20,14 @@
         {% if item.slides %}
           <a class="mt-1 text-decoration-none text-secondary stretched-link" href="{% asset '{{item.slides}}' @path %}" target="_blank">
             <i class="fa fa-download my-auto"></i> <small>{% t news.conference.slides %}</small>
-          </a>
+	  </a><br/>
         {% endif %}
+	{% if item.links %}
+	 {% for link in item.links %}
+	  <a class="mt-1 text-decoration-none text-secondary stretched-link" href="{link}" target="_blank">
+	   <i class="fa fa-link my-auto"></i> </a>
+	 {% endfor %}
+	{% endif %}
       </div>
     </div>
   </div>

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -7,7 +7,12 @@
     <div class="d-flex w-100 justify-content-between">
       <div class="d-flex w-75 flex-column justify-content-start position-relative">
         <h5 style="font-size:.875em">{{item.event}}</h5>
-        <a href="{{item.link}}" target="_blank" class="mb-1 text-decoration-none text-body stretched-link">{{item.title}}</a>
+	{% if item.link %}
+          <a href="{{item.link}}" target="_blank" class="mb-1 text-decoration-none text-body stretched-link">
+	   <i class="fa fa-link my-auto"></i> {{item.title}}</a>
+	{% else %}
+	{{item.title}}
+	{% endif %}
         {% if item.details %}<p class="mb-1 small fw-light">— {{item.details}}</p>{% endif %}
       </div>
       <div class="d-flex w-25 flex-column justify-content-start text-end position-relative">

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -9,7 +9,7 @@
         <h5 style="font-size:.875em">{{item.event}}</h5>
 	{% if item.link %}
           <a href="{{item.link}}" target="_blank" class="mb-1 text-decoration-none text-body stretched-link">
-	   <i class="fa fa-link my-auto"></i> {{item.title}}</a>
+	   <small><i class="fa fa-up-right-from-square my-auto"></i></small> {{item.title}}</a>
 	{% else %}
 	{{item.title}}
 	{% endif %}

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -9,7 +9,7 @@
         <h5 style="font-size:.875em">{{item.event}}</h5>
 	{% if item.link %}
           <a href="{{item.link}}" target="_blank" class="mb-1 text-decoration-none text-body stretched-link">
-	   <small><i class="fa caret-square-o-right my-auto"></i></small> {{item.title}}</a>
+	   <small><i class="fa fa-caret-square-o-right my-auto"></i></small> {{item.title}}</a>
 	{% else %}
 	{{item.title}}
 	{% endif %}

--- a/_includes/news/conferences.html
+++ b/_includes/news/conferences.html
@@ -9,7 +9,7 @@
         <h5 style="font-size:.875em">{{item.event}}</h5>
 	{% if item.link %}
           <a href="{{item.link}}" target="_blank" class="mb-1 text-decoration-none text-body stretched-link">
-	   <small><i class="fa fa-up-right-from-square my-auto"></i></small> {{item.title}}</a>
+	   <small><i class="fa fa-square-caret-right my-auto"></i></small> {{item.title}}</a>
 	{% else %}
 	{{item.title}}
 	{% endif %}


### PR DESCRIPTION
Give users a visual clue when the title of the talk also is a link by adding a symbol.
Also allow for additional links (with just a link symbol).

We don't currently have information on the nature of these links, so just main link and and additional links.
This addresses #1095.
Some discussion to be found there.

This has been deployed to staging, so the visual results can be seen on
https://staging.scs.community/
in a few minutes.